### PR TITLE
update torch version due to older torch has serious vulnerability issues

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -36,7 +36,7 @@ python-dotenv>=1.2.1
 
 # ML/AI frameworks (CPU ONLY)
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
+torch>=2.6.0
 torchvision>=0.16.0
 ultralytics>=8.0.0
 transformers>=4.35.0


### PR DESCRIPTION
# issue
EnvironmentPlugin, ActivityPlugin failed to set up due to outdated pytorch version.

`[2025-12-18 05:58:28.947 +0000] DEBUG: [PythonService STDERR]: 2025-12-18 05:58:28,947 - ERROR - Failed to setup EnvironmentPlugin: Due to a serious vulnerability issue in torch.load, even with weights_only=True, we now require users to upgrade torch to at least v2.6 in order to use the function. This version restriction does not apply when loading files with safetensors. See the vulnerability report here https://nvd.nist.gov/vuln/detail/CVE-2025-32434 [2025-12-18 05:58:34.905 +0000] DEBUG: [PythonService STDERR]: 2025-12-18 05:58:34,905 - ERROR - Failed to setup ActivityPlugin: Due to a serious vulnerability issue in torch.load, even with weights_only=True, we now require users to upgrade torch to at least v2.6 in order to use the function. This version restriction does not apply when loading files with safetensors. See the vulnerability report here https://nvd.nist.gov/vuln/detail/CVE-2025-32434`

# change

modify requirements.txt, change torch version to 2.6.0


Fixes #16 