### PR TITLE
fix: update job folderId when the folder is not found

### DIFF
--- a/apps/background-jobs/src/jobs/videoFinalization.ts
+++ b/apps/background-jobs/src/jobs/videoFinalization.ts
@@ -24,17 +24,17 @@ async function finalizeVideo(job: Job<VideoProcessingData>) {
     const video = await getByVideoSource(videoPath)
 
     if (video) {
-      await importVideoFromVectorDb(video)
-      const folder = await FolderModel.findByPath(dirname(videoPath))
+      const folder = await importVideoFromVectorDb(video)
 
       if (folder) {
+        await updateJob(job, { folderId: folder.id })
         // We need to count all processing and pending to update the folder status to be indexed in the case of zero jobs count
         const jobsCount = await JobModel.count({
           where: {
             status: {
               in: ['pending', 'processing'],
             },
-            folderId: folder.id
+            folderId: folder.id,
           },
         })
         if (jobsCount === 0) {

--- a/apps/background-jobs/src/services/videoIndexer.ts
+++ b/apps/background-jobs/src/services/videoIndexer.ts
@@ -25,6 +25,7 @@ export async function updateJob(
     audioEmbeddingTime?: number
     visualEmbeddingTime?: number
     frameAnalysisPlugins?: Record<string, string | number>[]
+    folderId?: string
   }>
 ) {
   if (!job.data?.jobId) return

--- a/apps/background-jobs/src/utils/videos.ts
+++ b/apps/background-jobs/src/utils/videos.ts
@@ -4,8 +4,9 @@ import { THUMBNAILS_DIR } from '@shared/constants'
 import { generateVideoCover } from '@media-utils/utils/videos'
 import { Video } from '@shared/types/video'
 import { FolderModel, UserModel, VideoModel, generateId } from '@db/index'
+import { Folder } from '@prisma/client'
 
-export async function importVideoFromVectorDb(video: Video): Promise<void> {
+export async function importVideoFromVectorDb(video: Video): Promise<Folder | undefined> {
   try {
     const user = await UserModel.findFirst()
     if (!user) {
@@ -64,6 +65,7 @@ export async function importVideoFromVectorDb(video: Video): Promise<void> {
           folderId: folder?.id,
         },
       })
+      return folder
     } catch (videoError) {
       logger.error(`Failed to import video ${video.source}: ` + videoError)
     }


### PR DESCRIPTION
### Summary

An issue when finding the video file with 2+ depth levels, we will have a job processed, but the folder has not been created yet. When the video processing jobs are done, the folder is not created yet. We will create a folder and update the job folder id to use the child folder instead of the parent one. 