### PR TITLE
fix: move scene thumbnail creation to python script

### DIFF
--- a/packages/media-utils/src/constants/index.ts
+++ b/packages/media-utils/src/constants/index.ts
@@ -11,7 +11,7 @@ export const BATCH_THUMBNAIL_QUALITY = '3'
 
 export const MAX_DEPTH = 1
 
-export const THUMBNAILS_DIR = process.env.THUMBNAILS_PATH || '.thumbnails'
+export const THUMBNAILS_DIR = process.env.THUMBNAILS_PATH || '/app/data/.thumbnails'
 
 export const EXPORTS_DIR = process.env.EXPORTS_DIR || '/app/data/.exports'
 

--- a/packages/media-utils/src/utils/scenes.ts
+++ b/packages/media-utils/src/utils/scenes.ts
@@ -1,56 +1,18 @@
-import path from 'path'
-import { Analysis, DetectedObject, Face, FrameAnalysis } from '@shared/types/analysis'
+import { Analysis, DetectedObject, Face } from '@shared/types/analysis';
 import { Scene } from '@shared/types/scene'
 import { Transcription } from '@shared/types/transcription'
 import { createHash } from 'crypto'
-import { THUMBNAILS_DIR } from '@shared/constants'
 import { getCameraNameAndDate, getLocationFromVideo, getVideoMetadata } from '@media-utils/utils/videos'
 import { formatLocation, getLocationName } from '@shared/utils/location'
 import { extractGPS, getGoProDeviceName, getGoProVideoMetadata } from '@media-utils/lib/gopro'
 import { GoProMetadataWithStreams } from '@media-utils/types/gopro'
 import { logger } from '@shared/services/logger'
 import { gcd } from './shared'
-import { generateBatchThumbnails } from './thumbnails'
-import { ThumbnailRequest } from '@media-utils/types/thumbnail'
 
 const generateSceneId = (videoPath: string, startTime: number, endTime: number) => {
   const hash = createHash('sha256').update(`${videoPath}_${startTime}_${endTime}`).digest('hex')
 
   return hash
-}
-
-const generateThumbnailFilePath = (videoPath: string, startTime: number, endTime: number) => {
-  const hash = generateSceneId(videoPath, startTime, endTime)
-
-  const thumbnailFile = `${hash}.jpg`
-  const thumbnailPath = path.join(THUMBNAILS_DIR, thumbnailFile)
-  return thumbnailPath
-}
-
-const splitFramesIntoChunks = (frames: FrameAnalysis[], chunkDuration: number) => {
-  const chunks: FrameAnalysis[][] = []
-  let currentChunk: FrameAnalysis[] = []
-
-  for (const frame of frames) {
-    const frameStart = frame.start_time_ms / 1000
-    if (currentChunk.length === 0) {
-      currentChunk.push(frame)
-    } else {
-      const firstFrameStart = currentChunk[0].start_time_ms / 1000
-      if (frameStart - firstFrameStart < chunkDuration) {
-        currentChunk.push(frame)
-      } else {
-        chunks.push(currentChunk)
-        currentChunk = [frame]
-      }
-    }
-  }
-
-  if (currentChunk.length > 0) {
-    chunks.push(currentChunk)
-  }
-
-  return chunks
 }
 
 export const generateSceneDescription = (objects: DetectedObject[], faces: Face[]): string => {
@@ -162,42 +124,10 @@ export const createScenes = async (
 
   const locationName = await getLocationName(location)
 
-  // If the video duration is less than 3 minutes, use batch thumbnail generation
-  const CHUNK_DURATION = 3 * 60 // 3 minutes
-  const thumbnailStart = Date.now()
-
-  let frameChunks: FrameAnalysis[][] = []
-
-  if (duration <= CHUNK_DURATION) {
-    frameChunks = [analysis.frame_analysis] // small videos: one chunk
-  } else {
-    frameChunks = splitFramesIntoChunks(analysis.frame_analysis, CHUNK_DURATION)
-  }
-
-  // Generate thumbnails per chunk
-  for (let i = 0; i < frameChunks.length; i++) {
-    const chunk = frameChunks[i]
-    const requests: ThumbnailRequest[] = chunk.map((frame) => {
-      const startTime = frame.start_time_ms / 1000
-      const endTime = frame.end_time_ms / 1000
-      const thumbnailPath = generateThumbnailFilePath(videoPath, startTime, endTime)
-
-      return { startTime, outputPath: thumbnailPath, endTime }
-    })
-
-    await generateBatchThumbnails(videoPath, requests)
-
-  }
-
-  const thumbnailEnd = Date.now()
-  logger.info(
-    `Thumbnail generation completed in : ${(thumbnailEnd - thumbnailStart) / 1000}s`
-  )
 
   for (const frame of analysis.frame_analysis) {
     const startTime = frame.start_time_ms / 1000
     const endTime = frame.end_time_ms / 1000
-    const thumbnailPath = generateThumbnailFilePath(videoPath, startTime, endTime)
     const id = generateSceneId(videoPath, startTime, endTime)
     const currentScene: Scene = {
       id,
@@ -216,7 +146,7 @@ export const createScenes = async (
       source: videoPath,
       camera,
       createdAt: new Date(createdAt).getTime(),
-      thumbnailUrl: thumbnailPath,
+      thumbnailUrl: frame.thumbnail_path,
       dominantColorHex: frame.dominant_color?.hex || '',
       dominantColorName: frame.dominant_color?.name || '',
       detectedText: frame.detected_text?.map((item) => item.text) || [],

--- a/packages/media-utils/src/utils/thumbnails.ts
+++ b/packages/media-utils/src/utils/thumbnails.ts
@@ -1,13 +1,8 @@
 import fs from 'fs'
-import { dirname, join } from 'path'
-import { tmpdir } from 'os'
 import { THUMBNAIL_QUALITY, THUMBNAIL_SCALE, THUMBNAILS_DIR } from '../constants'
 import { handleFFmpegProcess, spawnFFmpeg } from '../lib/ffmpeg'
 import { validateFile } from '@shared/utils/file'
-import { logger } from '@shared/services/logger'
 import { getGPUDecodeArgs } from '@media-utils/lib/ffmpegGpu'
-import { BatchThumbnailOptions, ThumbnailRequest } from '@media-utils/types/thumbnail'
-import { randomBytes } from 'crypto'
 
 const initializeThumbnailsDir = (): void => {
   if (!fs.existsSync(THUMBNAILS_DIR)) {
@@ -87,86 +82,4 @@ export async function generateVideoCover(
 
   const ffmpegProcess = await spawnFFmpeg(args)
   return handleFFmpegProcess(ffmpegProcess, 'thumbnail generation')
-}
-
-export async function generateBatchThumbnails(
-  videoPath: string,
-  requests: ThumbnailRequest[],
-  options?: BatchThumbnailOptions
-): Promise<void> {
-  await validateFile(videoPath)
-
-  if (requests.length === 0) {
-    logger.warn('No thumbnail requests provided')
-    return
-  }
-
-  const startTime = Date.now()
-  const quality = options?.quality ?? THUMBNAIL_QUALITY
-  const scale = options?.scale ?? THUMBNAIL_SCALE
-
-  // Sort by timestamp
-  const sortedRequests = [...requests].sort((a, b) => a.startTime - b.startTime)
-
-  const outputDirs = new Set(sortedRequests.map((req) => dirname(req.outputPath)))
-  for (const dir of outputDirs) {
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true })
-    }
-  }
-
-  // Create temporary directory for frame extraction
-  const sessionId = randomBytes(8).toString('hex')
-  const tempDir = join(tmpdir(), 'edit-mind-thumbnails', sessionId)
-  fs.mkdirSync(tempDir, { recursive: true })
-
-  try {
-    // Build select expression for all timestamps
-    // Using between() for more precise frame selection
-    const selectExpr = sortedRequests.map((req) => `between(t,${req.startTime},${req.endTime})`).join('+')
-
-    const args: string[] = [
-      ...getGPUDecodeArgs(),
-      '-i',
-      videoPath,
-      '-vf',
-      `select='${selectExpr}',scale=${scale}`,
-      '-vsync',
-      '0',
-      '-frame_pts',
-      '1',
-      '-q:v',
-      quality,
-      join(tempDir, 'frame_%d.jpg'),
-      '-y',
-      '-loglevel',
-      'error',
-    ]
-
-    const ffmpegProcess = await spawnFFmpeg(args)
-    await handleFFmpegProcess(ffmpegProcess, 'batch thumbnail extraction')
-
-    // Read extracted frames and map them to requested outputs
-    const extractedFrames = fs.readdirSync(tempDir).filter((f) => f.startsWith('frame_'))
-
-    // Copy frames to their final destinations
-    for (let i = 0; i < Math.min(extractedFrames.length, sortedRequests.length); i++) {
-      const sourcePath = join(tempDir, extractedFrames[i])
-      const destPath = sortedRequests[i].outputPath
-      fs.copyFileSync(sourcePath, destPath)
-    }
-
-    if (extractedFrames.length < sortedRequests.length) {
-      logger.warn(`Only extracted ${extractedFrames.length} frames out of ${sortedRequests.length} requested`)
-    }
-
-    const endTime = Date.now()
-
-    logger.info(`Thumbnails extracted in ${(endTime - startTime) / 1000}s`)
-  } finally {
-    // Cleanup temp directory
-    if (fs.existsSync(tempDir)) {
-      fs.rmSync(tempDir, { recursive: true, force: true })
-    }
-  }
 }

--- a/packages/shared/src/types/analysis.ts
+++ b/packages/shared/src/types/analysis.ts
@@ -39,6 +39,7 @@ export interface FrameAnalysis {
     is_muted: boolean
   }
   description: string
+  thumbnail_path:string
 }
 
 export interface DetectedText {

--- a/python/core/config.py
+++ b/python/core/config.py
@@ -20,7 +20,12 @@ class AnalysisConfig:
         'ShotTypePlugin': 1,
         "DescriptorPlugin": 1
     })
-
+    thumbnail_dir: str = field(
+        default_factory=lambda: os.getenv(
+            "THUMBNAILS_PATH",
+            "/app/data/.thumbnails/"
+        )
+    )
     def __post_init__(self) -> None:
         """Post-initialization adjustments."""
         self._adjust_for_memory()

--- a/python/core/types.py
+++ b/python/core/types.py
@@ -46,6 +46,7 @@ class FrameAnalysis(TypedDict, total=False):
     frame_idx: int
     scale_factor: float
     job_id: str
+    thumbnail_path: str
 
 
 # Service States


### PR DESCRIPTION
### Summary 

- Move the scene thumbnail from using `FFmpeg` to the frame analysis stage to drastically reduce the scene creation time and get the exact frame image used for processing 