### PR TITLE
fix: cuda availability checker issue over web docker service with no …

### DIFF
--- a/packages/embedding-core/src/services/extractors.ts
+++ b/packages/embedding-core/src/services/extractors.ts
@@ -41,7 +41,7 @@ export async function getFrameExtractor() {
 
     const processor = await AutoProcessor.from_pretrained(VISUAL_EMBEDDING_MODEL)
     const model = await CLIPVisionModelWithProjection.from_pretrained(VISUAL_EMBEDDING_MODEL, {
-      device: USE_GPU ? "cuda" : "auto",
+      device: USE_GPU ? "cuda" : "cpu",
       dtype: "fp16"
     })
     visualModelCache = { processor, model }
@@ -53,7 +53,7 @@ export async function getAudioExtractor() {
   if (!audioModelCache) {
     const processor = await AutoProcessor.from_pretrained(AUDIO_EMBEDDING_MODEL)
     const model = await ClapAudioModelWithProjection.from_pretrained(AUDIO_EMBEDDING_MODEL, {
-      device: USE_GPU ? "cuda" : "auto"
+      device: USE_GPU ? "cuda" : "cpu"
     })
 
     audioModelCache = { processor, model }
@@ -66,7 +66,7 @@ async function getTextToVisualExtractor() {
 
     const tokenizer = await AutoTokenizer.from_pretrained(VISUAL_EMBEDDING_MODEL)
     const model = await CLIPTextModelWithProjection.from_pretrained(VISUAL_EMBEDDING_MODEL, {
-      device: USE_GPU ? "cuda" : "auto",
+      device: USE_GPU ? "cuda" : "cpu",
       dtype: "fp16"
     })
     textToVisualModelCache = { tokenizer, model }
@@ -122,7 +122,7 @@ export async function getTextExtractor() {
   if (!textModelCache) {
 
     const embed = await pipeline('feature-extraction', TEXT_EMBEDDING_MODEL, {
-      device: USE_GPU ? "cuda" : "auto",
+      device: USE_GPU ? "cuda" : "cpu",
       dtype: "fp16"
     })
 

--- a/packages/shared/src/constants/gpu.ts
+++ b/packages/shared/src/constants/gpu.ts
@@ -1,3 +1,12 @@
+import { logger } from "@shared/services/logger";
 import { isGPUAvailable } from "@shared/utils/gpu";
 
-export const USE_GPU = isGPUAvailable() 
+export let USE_GPU = false;
+
+(async function initGPU(): Promise<void> {
+    try {
+        USE_GPU = await isGPUAvailable();
+    } catch (error) {
+        logger.error({ error }, 'Failed to initialize GPU — defaulting to CPU');
+    }
+})()

--- a/packages/shared/src/utils/gpu.ts
+++ b/packages/shared/src/utils/gpu.ts
@@ -1,11 +1,24 @@
-import { execSync } from 'child_process';
+import { logger } from '@shared/services/logger';
 
-export function isGPUAvailable(): boolean {
+let _gpuAvailable: boolean | null = null;
+
+const MINIMAL_ONNX_MODEL = Buffer.from([
+  0x08, 0x07, 0x12, 0x00, 0x2a, 0x00, 0x3a, 0x00,
+]);
+
+export async function isGPUAvailable(): Promise<boolean> {
+  if (_gpuAvailable !== null) return _gpuAvailable;
+
   try {
-    // Check if nvidia-smi is available
-    execSync('nvidia-smi', { stdio: 'ignore' });
-    return true;
+    const ort = await import('onnxruntime-node');
+    await ort.InferenceSession.create(MINIMAL_ONNX_MODEL, {
+      executionProviders: ['CUDAExecutionProvider'],
+    });
+    _gpuAvailable = true;
+    logger.info('GPU available');
   } catch {
-    return false;
+    _gpuAvailable = false;
+    logger.info('GPU unavailable — fallback to CPU');
   }
+  return _gpuAvailable;
 }


### PR DESCRIPTION
### Overview 


`isGPUAvailable()` returns `true` on machines where the NVIDIA driver is installed but the CUDA toolkit libraries (e.g. `libcublasLt.so.12`) are missing or on the wrong version. This causes ONNX Runtime to throw at model load time and not at GPU detection time, making the failure hard to trace. #85 

### Expected behavior

`isGPUAvailable()` should return `true` only when the full CUDA stack is confirmed to be functional.

### Actual behavior

`isGPUAvailable()` returns `true` based on driver presence alone, then ONNX Runtime crashes at model initialization with a missing shared library error.


### Changes:

Replace shell-based detection with an actual ONNX Runtime CUDA session creation using a minimal valid ONNX model. This validates the full CUDA stack end-to-end