### PR TITLE
feat: add support for MXF videos by transcoding to MP4

### DIFF
--- a/apps/background-jobs/src/index.ts
+++ b/apps/background-jobs/src/index.ts
@@ -31,8 +31,10 @@ import {
   videoFinalizationQueue,
   faceRenameQueue,
   updateVideoQueue,
+  transcodingVideoQueue
 } from './queue'
 
+import './jobs/transcoding'
 import './jobs/transcription'
 import './jobs/frameAnalysis'
 import './jobs/sceneCreation'
@@ -78,6 +80,7 @@ if (process.env.NODE_ENV === 'development' || env.ENABLE_QUEUE_UI) {
 
   createBullBoard({
     queues: [
+      new BullMQAdapter(transcodingVideoQueue),
       new BullMQAdapter(transcriptionQueue),
       new BullMQAdapter(frameAnalysisQueue),
       new BullMQAdapter(sceneCreationQueue),

--- a/apps/background-jobs/src/jobs/transcoding.ts
+++ b/apps/background-jobs/src/jobs/transcoding.ts
@@ -1,0 +1,43 @@
+import { Worker, Job } from 'bullmq'
+import { connection } from '../services/redis'
+import { logger } from '@shared/services/logger'
+import { VideoProcessingData } from '@shared/types/video'
+import { updateJob } from '../services/videoIndexer';
+import { JobStatus } from '@prisma/client'
+import { transcodeVideo } from '@media-utils/utils/trancoding'
+import { dirname } from 'path';
+
+async function processVideo(job: Job<VideoProcessingData>) {
+    const { jobId, videoPath } = job.data
+
+    logger.debug({ jobId }, 'Starting video transcoding')
+
+    try {
+        const transcodingStartTime = Date.now()
+
+        await updateJob(job, { status: 'processing', overallProgress: 0, stage: "transcoding" })
+        
+        const videoFolder = dirname(videoPath)
+
+        const transcodedVideoFile = await transcodeVideo(videoPath, videoFolder)
+
+        const transcodingTime = (Date.now() - transcodingStartTime) / 1000
+
+        await updateJob(job, { status: 'done', progress: 100, stage: "transcoding", transcodingTime, overallProgress: 1000 })
+
+        return transcodedVideoFile
+
+    } catch (error) {
+        logger.error({ jobId, error, stack: error instanceof Error ? error.stack : undefined }, 'Video transcoding failed')
+        await updateJob(job, { status: JobStatus.error })
+        throw error
+    }
+}
+
+export const videoTranscodingWorker = new Worker('transcoding-video', processVideo, {
+    connection,
+    concurrency: 5,
+    lockDuration: 5 * 60 * 1000,
+    stalledInterval: 30 * 1000,
+    maxStalledCount: 3,
+})

--- a/apps/background-jobs/src/queue.ts
+++ b/apps/background-jobs/src/queue.ts
@@ -158,6 +158,16 @@ export const updateVideoQueue = createQueue('update-video', {
   },
 })
 
+export const transcodingVideoQueue = createQueue('transcoding-video', {
+  defaultJobOptions: {
+    attempts: 5,
+    backoff: {
+      type: 'exponential',
+      delay: 3000,
+    },
+  },
+})
+
 export const videoProcessingQueues = [
   transcriptionQueue,
   frameAnalysisQueue,
@@ -165,4 +175,5 @@ export const videoProcessingQueues = [
   textEmbeddingQueue,
   visualEmbeddingQueue,
   audioEmbeddingQueue,
+  transcodingVideoQueue
 ]

--- a/apps/background-jobs/src/services/videoIndexer.ts
+++ b/apps/background-jobs/src/services/videoIndexer.ts
@@ -4,10 +4,11 @@ import { logger } from '@shared/services/logger'
 import { UpdateSceneData, VideoIndexJobData, VideoProcessingData } from '@shared/types/video'
 import path from 'path'
 import { PROCESSED_VIDEOS_DIR } from '@shared/constants'
-import { transcriptionQueue, updateVideoQueue } from '@background-jobs/queue'
+import { transcodingVideoQueue, transcriptionQueue, updateVideoQueue } from '@background-jobs/queue'
 import { JobModel } from '@db/index'
 import { getVideoMetadata } from '@media-utils/utils/videos'
 import { createHash } from 'crypto'
+import { TRANSCODE_REQUIRED_EXTENSIONS } from '@shared/constants/video'
 
 export async function updateJob(
   job: Job<VideoIndexJobData>,
@@ -24,6 +25,7 @@ export async function updateJob(
     textEmbeddingTime?: number
     audioEmbeddingTime?: number
     visualEmbeddingTime?: number
+    transcodingTime?: number
     frameAnalysisPlugins?: Record<string, string | number>[]
     frameAnalysisStages?: Record<string, string | number>[]
     folderId?: string
@@ -50,6 +52,7 @@ export async function updateJob(
     if (data.textEmbeddingTime) updateData.textEmbeddingTime = data.textEmbeddingTime
     if (data.audioEmbeddingTime) updateData.audioEmbeddingTime = data.audioEmbeddingTime
     if (data.visualEmbeddingTime) updateData.visualEmbeddingTime = data.visualEmbeddingTime
+    if (data.transcodingTime) updateData.transcodingTime = data.transcodingTime
     if (data.frameAnalysisPlugins) {
       updateData.frameAnalysisPlugins = data.frameAnalysisPlugins
     }
@@ -78,6 +81,16 @@ export async function addVideoIndexingJob(jobData: VideoIndexJobData, priority: 
   const transcriptionPath = path.join(encodeURI(videoDir), 'transcription.json')
   const scenesPath = path.join(encodeURI(videoDir), 'scenes.json')
 
+  if (TRANSCODE_REQUIRED_EXTENSIONS.test(jobData.videoPath)) {
+    await transcodingVideoQueue.add('transcoding-video',
+      jobData, {
+      removeOnComplete: false,
+      removeOnFail: false,
+    }
+    )
+    logger.debug(`Video file queued for transcoding before indexing: ${jobData.videoPath}`)
+    return
+  }
   const metadata = await getVideoMetadata(jobData.videoPath)
 
   const videoData: VideoProcessingData = {

--- a/apps/background-jobs/src/utils/videos.ts
+++ b/apps/background-jobs/src/utils/videos.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import { logger } from '@shared/services/logger'
 import { THUMBNAILS_DIR } from '@shared/constants'
+import { EXCLUDED_VIDEO_PATTERNS, SUPPORTED_VIDEO_PATTERNS } from '@shared/constants/video'
 import { generateVideoCover } from '@media-utils/utils/thumbnails'
 import { Video } from '@shared/types/video'
 import { FolderModel, UserModel, VideoModel, generateId } from '@db/index'
@@ -30,8 +31,8 @@ export async function importVideoFromVectorDb(video: Video): Promise<Folder | un
           path: path.dirname(video.source),
           watcherEnabled: true,
           userId: user.id,
-          excludePatterns: ['*.part', '*.temp'],
-          includePatterns: ['*.mp4', '*.mov', '*.avi', '*.mkv'],
+          excludePatterns: EXCLUDED_VIDEO_PATTERNS,
+          includePatterns: SUPPORTED_VIDEO_PATTERNS,
         })
       }
 

--- a/apps/background-jobs/src/watcher.ts
+++ b/apps/background-jobs/src/watcher.ts
@@ -1,6 +1,6 @@
 import chokidar from 'chokidar'
 import path from 'path'
-import { SUPPORTED_VIDEO_EXTENSIONS } from '@shared/constants'
+import { SUPPORTED_VIDEO_EXTENSIONS } from '@shared/constants/video'
 import { addVideoIndexingJob } from './services/videoIndexer.js'
 import { FolderModel, JobModel } from '@db/index.js'
 import { stat } from 'fs/promises'

--- a/apps/background-jobs/tests/mocks/database.ts
+++ b/apps/background-jobs/tests/mocks/database.ts
@@ -21,6 +21,7 @@ import {
   ExportStatus,
   Prisma,
 } from '@prisma/client'
+import { EXCLUDED_VIDEO_PATTERNS, SUPPORTED_VIDEO_PATTERNS } from '@shared/constants/video'
 import { nanoid } from 'nanoid'
 
 /**
@@ -315,8 +316,8 @@ export const MockFolderModel = {
       createdAt: new Date(),
       watcherEnabled: data.watcherEnabled || true,
       lastWatcherScan: data.lastWatcherScan || null,
-      excludePatterns: data.excludePatterns || ['*.part', '*.temp'],
-      includePatterns: data.includePatterns || ['*.mp4', '*.mov', '*.avi', '*.mkv'],
+      excludePatterns: data.excludePatterns || EXCLUDED_VIDEO_PATTERNS,
+      includePatterns: data.includePatterns || SUPPORTED_VIDEO_PATTERNS,
     }
     this.data.set(folder.id, folder)
     return folder

--- a/apps/web/app/features/folders/schemas/folder.ts
+++ b/apps/web/app/features/folders/schemas/folder.ts
@@ -1,3 +1,4 @@
+import { EXCLUDED_VIDEO_PATTERNS, SUPPORTED_VIDEO_PATTERNS } from '@shared/constants/video'
 import { z } from 'zod'
 
 export const FolderCreateSchema = z.object({
@@ -7,10 +8,10 @@ export const FolderCreateSchema = z.object({
     .default(true),
   includePatterns: z
     .array(z.string())
-    .default(['*.mp4', '*.mov', '*.avi', '*.mkv']),
+    .default(SUPPORTED_VIDEO_PATTERNS),
   excludePatterns: z
     .array(z.string())
-    .default(['*.part', '*.temp']),
+    .default(EXCLUDED_VIDEO_PATTERNS),
 })
 
 export const FolderUpdateSchema = z.object({
@@ -19,8 +20,8 @@ export const FolderUpdateSchema = z.object({
     .default(true),
   includePatterns: z
     .array(z.string())
-    .default(['*.mp4', '*.mov', '*.avi', '*.mkv']),
+    .default(SUPPORTED_VIDEO_PATTERNS),
   excludePatterns: z
     .array(z.string())
-    .default(['*.part', '*.temp']),
+    .default(EXCLUDED_VIDEO_PATTERNS),
 })

--- a/apps/web/app/features/jobs/components/JobCard.tsx
+++ b/apps/web/app/features/jobs/components/JobCard.tsx
@@ -6,6 +6,7 @@ import { getStageLabel, getStatusColor } from '~/features/jobs/utils'
 import { JobStageIcon } from '~/features/jobs/components/JobStageIcon'
 import { JobStatusIcon } from '~/features/jobs/components/JobStatusIcon'
 import type { Job } from '@prisma/client'
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/solid'
 
 export const meta: MetaFunction = () => {
   return [{ title: 'Jobs | Edit Mind' }]
@@ -62,6 +63,12 @@ export const JobCard: React.FC<JobCardProps> = ({ job }) => {
       {job.status === 'done' && (
         <div className="px-5 pb-5 pt-3 border-t border-white/5">
           <div className="grid grid-cols-3 gap-4 text-xs">
+            {job.transcodingTime && (
+              <div className="flex items-center gap-2">
+                <ArrowsRightLeftIcon className="w-3.5 h-3.5 text-white/40" />
+                <span className="text-white/60">Transcoding: {humanizeSeconds(job.transcodingTime)}</span>
+              </div>
+            )}
             {job.transcriptionTime && (
               <div className="flex items-center gap-2">
                 <LanguageIcon className="w-3.5 h-3.5 text-white/40" />

--- a/apps/web/app/features/jobs/components/JobStageIcon.tsx
+++ b/apps/web/app/features/jobs/components/JobStageIcon.tsx
@@ -7,6 +7,7 @@ import {
   CubeIcon,
   SparklesIcon,
 } from '@heroicons/react/24/outline';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/solid';
 
 export const JobStageIcon = ({ stage }: { stage: Job['stage'] }) => {
   switch (stage) {
@@ -24,6 +25,8 @@ export const JobStageIcon = ({ stage }: { stage: Job['stage'] }) => {
       return <PhotoIcon className="w-4 h-4" />
     case 'embedding_audio':
       return <SpeakerWaveIcon className="w-4 h-4" />
+    case 'transcoding':
+      return <ArrowsRightLeftIcon className="w-4 h-4" />
     default:
       return null
   }

--- a/apps/web/app/features/jobs/utils/index.ts
+++ b/apps/web/app/features/jobs/utils/index.ts
@@ -2,6 +2,8 @@ import type { Job } from "@prisma/client"
 
 export const getStageLabel = (stage: Job['stage']) => {
     switch (stage) {
+        case 'transcoding':
+            return 'Transcoding'
         case 'starting':
             return 'Starting'
         case 'transcribing':

--- a/apps/web/app/routes/api.media.files.ts
+++ b/apps/web/app/routes/api.media.files.ts
@@ -2,7 +2,7 @@ import type { LoaderFunctionArgs } from 'react-router'
 import pathModule from 'path'
 import fs from 'fs/promises'
 import { MEDIA_BASE_PATH } from '@shared/constants'
-import { SUPPORTED_VIDEO_EXTENSIONS } from '@shared/constants'
+import { SUPPORTED_VIDEO_EXTENSIONS } from '@shared/constants/video'
 import { logger } from '@shared/services/logger'
 import { createPathValidator } from '@shared/services/pathValidator'
 

--- a/apps/web/app/routes/app.settings.tsx
+++ b/apps/web/app/routes/app.settings.tsx
@@ -3,7 +3,7 @@ import { Sidebar } from '~/features/shared/components/Sidebar'
 import { type MetaFunction } from 'react-router'
 import { Tabs } from '~/features/settings/components/Tabs'
 import FolderSettings from '~/features/settings/components/FolderSettings'
-import { FolderArrowDownIcon, Cog6ToothIcon, UserCircleIcon } from '@heroicons/react/24/solid'
+import { FolderArrowDownIcon, Cog6ToothIcon } from '@heroicons/react/24/solid';
 import { useState } from 'react'
 import { AdvancedSettings } from '~/features/settings/components/AdvancedSettings'
 

--- a/apps/web/tests/e2e/settings.spec.ts
+++ b/apps/web/tests/e2e/settings.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { EXCLUDED_VIDEO_PATTERNS, SUPPORTED_VIDEO_PATTERNS } from '@shared/constants/video'
 
 test.describe('Settings Page - Display and Management', () => {
   test.beforeEach(async ({ page }) => {
@@ -96,8 +97,8 @@ test.describe('Settings Page - Display and Management', () => {
               createdAt: new Date().toISOString(),
               watcherEnabled: true,
               lastWatcherScan: null,
-              excludePatterns: ['*.part', '*.temp'],
-              includePatterns: ['*.mp4', '*.mov', '*.avi', '*.mkv'],
+              excludePatterns: EXCLUDED_VIDEO_PATTERNS,
+              includePatterns: SUPPORTED_VIDEO_PATTERNS,
             },
           ],
           totalVideos: 5,
@@ -199,8 +200,8 @@ test.describe('Settings Page', () => {
               createdAt: new Date().toISOString(),
               watcherEnabled: true,
               lastWatcherScan: null,
-              excludePatterns: ['*.part', '*.temp'],
-              includePatterns: ['*.mp4', '*.mov', '*.avi', '*.mkv'],
+              excludePatterns: EXCLUDED_VIDEO_PATTERNS,
+              includePatterns: SUPPORTED_VIDEO_PATTERNS
             },
           ],
           totalVideos: 1,
@@ -258,8 +259,8 @@ test.describe('Settings Persistence', () => {
             createdAt: new Date().toISOString(),
             watcherEnabled: true,
             lastWatcherScan: null,
-            excludePatterns: ['*.part', '*.temp'],
-            includePatterns: ['*.mp4', '*.mov', '*.avi', '*.mkv'],
+            excludePatterns: EXCLUDED_VIDEO_PATTERNS,
+            includePatterns: SUPPORTED_VIDEO_PATTERNS
           },
         ],
         totalVideos: 5,
@@ -310,8 +311,8 @@ test.describe('Settings Persistence', () => {
             createdAt: new Date().toISOString(),
             watcherEnabled: true,
             lastWatcherScan: null,
-            excludePatterns: ['*.part', '*.temp'],
-            includePatterns: ['*.mp4', '*.mov', '*.avi', '*.mkv'],
+            excludePatterns: EXCLUDED_VIDEO_PATTERNS,
+            includePatterns: SUPPORTED_VIDEO_PATTERNS
           },
           {
             id: '456',
@@ -417,8 +418,8 @@ test.describe('Settings Reset and Validation', () => {
               createdAt: new Date().toISOString(),
               watcherEnabled: true,
               lastWatcherScan: null,
-              excludePatterns: ['*.part', '*.temp'],
-              includePatterns: ['*.mp4', '*.mov', '*.avi', '*.mkv'],
+              excludePatterns: EXCLUDED_VIDEO_PATTERNS,
+              includePatterns: SUPPORTED_VIDEO_PATTERNS
             },
           ],
           totalVideos: 5,
@@ -543,8 +544,8 @@ test.describe('Settings Reset Functionality', () => {
             createdAt: new Date().toISOString(),
             watcherEnabled: true,
             lastWatcherScan: null,
-            excludePatterns: ['*.part', '*.temp'],
-            includePatterns: ['*.mp4', '*.mov', '*.avi', '*.mkv'],
+            excludePatterns: EXCLUDED_VIDEO_PATTERNS,
+            includePatterns: SUPPORTED_VIDEO_PATTERNS
           },
         ],
         totalVideos: 5,
@@ -613,8 +614,8 @@ test.describe('Settings Reset Functionality', () => {
             createdAt: new Date().toISOString(),
             watcherEnabled: true,
             lastWatcherScan: null,
-            excludePatterns: ['*.part', '*.temp'],
-            includePatterns: ['*.mp4', '*.mov', '*.avi', '*.mkv'],
+            excludePatterns: EXCLUDED_VIDEO_PATTERNS,
+            includePatterns: SUPPORTED_VIDEO_PATTERNS
           },
         ],
         totalVideos: 5,

--- a/apps/web/tests/e2e/setup.spec.ts
+++ b/apps/web/tests/e2e/setup.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { EXCLUDED_VIDEO_PATTERNS, SUPPORTED_VIDEO_PATTERNS } from '@shared/constants/video'
 
 test.beforeEach(async ({ page }) => {
     await page.goto('/auth/login')
@@ -145,8 +146,8 @@ test.describe('Setup Flow - Display and Navigation', () => {
                         createdAt: new Date().toISOString(),
                         watcherEnabled: true,
                         lastWatcherScan: null,
-                        excludePatterns: ['*.part', '*.temp'],
-                        includePatterns: ['*.mp4', '*.mov', '*.avi', '*.mkv'],
+                        excludePatterns: EXCLUDED_VIDEO_PATTERNS,
+                        includePatterns: SUPPORTED_VIDEO_PATTERNS,
                     },
                 }
 

--- a/docker-compose.cuda.yml
+++ b/docker-compose.cuda.yml
@@ -20,7 +20,7 @@ services:
     networks:
       - app-network
     volumes:
-      - ${HOST_MEDIA_PATH:-./media}:/media/videos:ro
+      - ${HOST_MEDIA_PATH:-./media}:/media/videos:rw
       - .data:/app/data
       - ml-models:/app/ml-models:rw
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     networks:
       - app-network
     volumes:
-      - ${HOST_MEDIA_PATH:-./media}:/media/videos:ro
+      - ${HOST_MEDIA_PATH:-./media}:/media/videos:rw
       - .data:/app/data
       - ml-models:/app/ml-models:rw
   web:

--- a/docker/docker-compose.cuda.yml
+++ b/docker/docker-compose.cuda.yml
@@ -29,7 +29,7 @@ services:
     networks:
       - app-network
     volumes:
-      - ${HOST_MEDIA_PATH:-./media}:/media/videos:ro
+      - ${HOST_MEDIA_PATH:-./media}:/media/videos:rw
       - ../.data:/app/data
       - ml-models:/ml-models:rw
   web:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
     networks:
       - app-network-dev
     volumes:
-      - ${HOST_MEDIA_PATH:-./media}:/media/videos:ro
+      - ${HOST_MEDIA_PATH:-./media}:/media/videos:rw
       - ../.data:/app/data
       - ../apps/background-jobs:/app/apps/background-jobs
       - ../packages/shared:/app/packages/shared

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     networks:
       - app-network
     volumes:
-      - ${HOST_MEDIA_PATH:-./media}:/media/videos:ro
+      - ${HOST_MEDIA_PATH:-./media}:/media/videos:rw
       - ../.data:/app/data
       - ml-models:/ml-models:rw
   web:

--- a/packages/db/src/models/Folder.ts
+++ b/packages/db/src/models/Folder.ts
@@ -1,6 +1,7 @@
 import type { Folder, Prisma } from '@prisma/client'
 import prisma from '../db'
 import { nanoid } from 'nanoid'
+import { EXCLUDED_VIDEO_PATTERNS, SUPPORTED_VIDEO_PATTERNS } from '@shared/constants/video'
 
 type FolderUpdateData = Partial<Omit<Folder, 'id' | 'userId'>>
 
@@ -12,6 +13,8 @@ export class FolderModel {
       data: {
         id: nanoid(),
         ...data,
+        excludePatterns: data.excludePatterns ?? EXCLUDED_VIDEO_PATTERNS,
+        includePatterns: data.excludePatterns ?? SUPPORTED_VIDEO_PATTERNS
       },
     })
     return folder

--- a/packages/media-utils/src/utils/trancoding.ts
+++ b/packages/media-utils/src/utils/trancoding.ts
@@ -1,0 +1,61 @@
+import { spawnFFmpeg } from '@media-utils/lib/ffmpeg'
+import path from 'path'
+import { existsSync } from 'fs'
+import { mkdir } from 'fs/promises'
+import { logger } from '@shared/services/logger'
+import { buildEncodingArgs } from '@media-utils/lib/ffmpegGpu'
+import { USE_FFMPEG_GPU } from '@media-utils/constants'
+
+export const transcodeVideo = async (
+  videoPath: string,
+  outputDir: string
+): Promise<string> => {
+  if (!existsSync(outputDir)) {
+    await mkdir(outputDir, { recursive: true })
+  }
+
+  const baseName = path.basename(videoPath, path.extname(videoPath))
+  const outputPath = path.join(outputDir, `${baseName}.mp4`)
+
+  logger.info(`Transcoding video to MP4 (GPU: ${USE_FFMPEG_GPU}): ${videoPath} to ${outputPath}`)
+
+  const encodingArgs = buildEncodingArgs({ encoder: 'h264' })
+
+  const ffmpegArgs = [
+    '-i',
+    videoPath,
+    ...encodingArgs,
+    '-y',
+    outputPath,
+  ]
+
+  try {
+    const ffmpegProcess = await spawnFFmpeg(ffmpegArgs)
+
+    await new Promise<void>((resolve, reject) => {
+      let stderr = ''
+
+      ffmpegProcess.stderr?.on('data', (data) => {
+        stderr += data.toString()
+      })
+
+      ffmpegProcess.on('close', (code) => {
+        if (code === 0) {
+          logger.info(`Transcoded video successfully: ${outputPath}`)
+          resolve()
+        } else {
+          reject(new Error(`FFmpeg exited with code ${code}: ${stderr}`))
+        }
+      })
+
+      ffmpegProcess.on('error', (err) => {
+        reject(new Error(`Failed to spawn FFmpeg: ${err.message}`))
+      })
+    })
+  } catch (error) {
+    logger.error({ error }, `Failed to transcode video: ${videoPath}`)
+    throw error
+  }
+
+  return outputPath
+}

--- a/packages/prisma/migrations/20260311215715_add_transcoding_video_processing_job_stage/migration.sql
+++ b/packages/prisma/migrations/20260311215715_add_transcoding_video_processing_job_stage/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "JobStage" ADD VALUE 'transcoding';

--- a/packages/prisma/migrations/20260311221009_add_video_trancoding_time_to_video_job/migration.sql
+++ b/packages/prisma/migrations/20260311221009_add_video_trancoding_time_to_video_job/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Job" ADD COLUMN     "transcodingTime" INTEGER;

--- a/packages/prisma/migrations/20260311232956_remove_folder_default_patterns/migration.sql
+++ b/packages/prisma/migrations/20260311232956_remove_folder_default_patterns/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Folder" ALTER COLUMN "excludePatterns" DROP DEFAULT,
+ALTER COLUMN "includePatterns" DROP DEFAULT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -67,8 +67,8 @@ model Folder {
 
   watcherEnabled    Boolean  @default(true)
   lastWatcherScan   DateTime?
-  excludePatterns   String[] @default(["*.part", "*.temp"])
-  includePatterns   String[] @default(["*.mp4", "*.mov", "*.avi", "*.mkv"])
+  excludePatterns   String[]
+  includePatterns   String[] 
 
   videos Video[]
 }
@@ -82,6 +82,7 @@ enum JobStatus {
 
 enum JobStage {
   starting
+  transcoding
   transcribing
   frame_analysis
   creating_scenes
@@ -113,6 +114,7 @@ model Job {
   textEmbeddingTime Int?  
   audioEmbeddingTime Int?  
   visualEmbeddingTime Int?
+  transcodingTime Int?
 
   frameAnalysisPlugins Json?
   frameAnalysisStages Json?

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,5 +1,3 @@
-import 'dotenv/config'
-
 // Directories
 export const THUMBNAILS_DIR = process.env.THUMBNAILS_PATH || '.thumbnails'
 export const FACES_DIR = process.env.FACES_DIR || '.faces'
@@ -8,7 +6,6 @@ export const UNKNOWN_FACES_DIR = process.env.UNKNOWN_FACES_DIR || '.unknown_face
 
 export const CACHE_FILE = '.locations.json'
 
-export const SUPPORTED_VIDEO_EXTENSIONS = /\.(mp4|mov|avi|mkv)$/i
 
 // Redis Cache
 export const CACHE_TTL = 5 * 60 * 1000 // 5 minutes

--- a/packages/shared/src/constants/video.ts
+++ b/packages/shared/src/constants/video.ts
@@ -1,0 +1,7 @@
+export const SUPPORTED_VIDEO_EXTENSIONS = /\.(mp4|mov|avi|mkv|mxf)$/i
+
+export const TRANSCODE_REQUIRED_EXTENSIONS = /\.(mxf)$/i
+
+export const SUPPORTED_VIDEO_PATTERNS = ['*.mp4', '*.mov', '*.avi', '*.mkv', '*.mxf']
+
+export const EXCLUDED_VIDEO_PATTERNS = ['*.part', '*.temp']


### PR DESCRIPTION
### Overview:

As requested by #53 (@sidgames5), I've added support for MXF videos by transcoding them first into an MP4 video to process the video as normal and make it viewable and playable over the web UI

Note: Make sure to update the Docker Compose YAML file, specifically this line over the background-jobs service from `- ${HOST_MEDIA_PATH:-./media}:/media/videos:ro` to `- ${HOST_MEDIA_PATH:-./media}:/media/videos:ro`. 

So, we can convert the MXF video file into an MP4 video file in the same original folder because we need write permissions to the media folder.