### PR TITLE
feat: add custom metadata when a face is recognized

### DIFF
--- a/apps/background-jobs/src/jobs/videoFinalization.ts
+++ b/apps/background-jobs/src/jobs/videoFinalization.ts
@@ -4,8 +4,7 @@ import { logger } from '@shared/services/logger'
 import { VideoProcessingData } from '@shared/types/video'
 import { updateJob } from '../services/videoIndexer'
 import { JobStatus } from '@prisma/client'
-import { unlink, rm } from 'fs/promises'
-import { existsSync } from 'fs'
+import { rm } from 'fs/promises';
 import { getByVideoSource } from '@vector/services/db'
 import { importVideoFromVectorDb } from '../utils/videos'
 import { suggestionCache } from '@search/services/suggestion'
@@ -45,27 +44,15 @@ async function finalizeVideo(job: Job<VideoProcessingData>) {
       }
     }
 
-    const filesToClean = [scenesPath, analysisPath, transcriptionPath]
-
     if (process.env.NODE_ENV === 'production') {
       logger.debug({ jobId }, 'Cleaning up temporary files')
 
-      for (const filePath of filesToClean) {
-        if (existsSync(filePath)) {
-          try {
-            await unlink(filePath)
-            logger.info({ jobId, filePath }, 'Deleted temporary file')
-          } catch (error) {
-            logger.warn({ jobId, filePath, error }, 'Failed to delete temporary file')
-          }
-        }
-      }
-    }
-    const videoDir = dirname(transcriptionPath)
+      const videoDir = dirname(transcriptionPath)
 
-    await rm(videoDir, {
-      recursive: true,
-    })
+      await rm(videoDir, {
+        recursive: true,
+      })
+    }
 
     await updateJob(job, { status: 'done', overallProgress: 100 })
     await suggestionCache.refresh()

--- a/apps/background-jobs/src/watcher.ts
+++ b/apps/background-jobs/src/watcher.ts
@@ -1,9 +1,9 @@
 import chokidar from 'chokidar'
 import path from 'path'
-import { addVideoIndexingJob } from './services/videoIndexer.js'
-import { FolderModel, JobModel } from '@db/index.js'
+import { addVideoIndexingJob } from './services/videoIndexer'
+import { FolderModel, JobModel } from '@db/index'
 import { stat } from 'fs/promises'
-import { logger } from '@shared/services/logger.js'
+import { logger } from '@shared/services/logger'
 import { existsSync } from 'fs'
 import micromatch from 'micromatch'
 

--- a/packages/media-utils/src/utils/scenes.ts
+++ b/packages/media-utils/src/utils/scenes.ts
@@ -1,4 +1,4 @@
-import { Analysis, DetectedObject, Face, PerformanceMetric } from '@shared/types/analysis';
+import { Analysis, DetectedObject, Face } from '@shared/types/analysis';
 import { Scene } from '@shared/types/scene'
 import { Transcription } from '@shared/types/transcription'
 import { createHash } from 'crypto'
@@ -160,6 +160,7 @@ export const createScenes = async (
           label: face.emotion.label,
           confidence: face.emotion.confidence,
         },
+        customMetadata: face.custom_metadata
       })),
       transcriptionWords: transcription?.segments
         .filter((segment) => segment.end >= startTime && segment.start <= endTime)

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -21,6 +21,7 @@ export const faceSchema = z.object({
     label: z.string().optional(),
     confidence: z.number().optional(),
   }),
+  customMetadata: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).nullable(),
 })
 
 export const objectDataSchema = z.object({

--- a/packages/shared/src/types/analysis.ts
+++ b/packages/shared/src/types/analysis.ts
@@ -7,6 +7,7 @@ export interface Face {
   }
   bbox: BBox
   confidence: number
+  custom_metadata: Record<string, string | number | boolean>
 }
 export interface BBox {
   x: number

--- a/packages/vector/src/utils/shared.ts
+++ b/packages/vector/src/utils/shared.ts
@@ -34,11 +34,20 @@ const generateVectorDocumentText = async (scene: Scene) => {
     } else if (faceList.length === 2) {
       textParts.push(` featuring ${faceList[0]} and ${faceList[1]}`)
     } else if (faceList.length > 2) {
-      const lastFace = faceList[faceList.length - 1]
-      const otherFaces = faceList.slice(0, -1).join(', ')
-      textParts.push(` featuring ${otherFaces}, and ${lastFace}`)
+      faceList?.forEach(face => textParts.push((` featuring ${face} `)))
     }
   }
+
+  // Faces custom metadata
+  const facesWithDetails = scene.facesData?.filter((face) => face.customMetadata && Object.keys(face.customMetadata).length > 0)
+    .map((face) => {
+      const attributes = Object.entries(face.customMetadata!)
+        .map(([key, value]) => `${key}: ${value}`)
+        .join(', ')
+      return ` ${face.name} (${attributes}) `
+    })
+
+  facesWithDetails?.forEach(metadata => textParts.push(metadata))
 
   // Objects detected
   if (objects) {

--- a/python/plugins/face_recognition.py
+++ b/python/plugins/face_recognition.py
@@ -67,6 +67,12 @@ class FaceRecognitionPlugin(AnalyzerPlugin):
         output_faces = []
         for face in recognized_faces:
             scaled_face = self._scale_face_coordinates(face, scale_factor, width, height)
+            
+            if not face['name'].startswith("Unknown_"):
+                custom_metadata = self._load_custom_face_metadata(face['name'])
+                if custom_metadata:
+                    scaled_face['custom_metadata'] = custom_metadata
+                
             output_faces.append(scaled_face)
 
             if face['name'].startswith("Unknown_"):
@@ -337,6 +343,29 @@ class FaceRecognitionPlugin(AnalyzerPlugin):
         if removed:
             logger.info(
                 f"Cleaned {removed} previous unknown faces for job {self.current_job_id}")
+
+    def _load_custom_face_metadata(self, name: str) -> Optional[Dict]:
+        """Load metadata.json from the known face's folder in FACE_DIR, if present.
+
+        Expected structure:
+            <FACE_DIR>/<name>/metadata.json
+
+        Returns the parsed dict on success, or None if the file doesn't exist or
+        cannot be read.
+        """
+        faces_dir = Path(os.getenv("FACES_DIR", ".faces"))  
+        metadata_file = faces_dir / name / "metadata.json"
+
+        if not metadata_file.exists():
+            return None
+
+        try:
+            data = json.loads(metadata_file.read_text(encoding="utf-8"))
+            logger.debug(f"Loaded custom metadata for '{name}' from {metadata_file}")
+            return data
+        except Exception as e:
+            logger.warning(f"Failed to load metadata.json for '{name}': {e}")
+            return None
 
     def get_results(self) -> PluginResult:
         """" Get all faces back"""


### PR DESCRIPTION
### Overview

This PR introduces a new capability that allows the system to load custom metadata for known faces and attach it to face recognition results. This feature has been requested by a community user.  

Over the face folder, for example, `FACE_DIR/Ilias/metadata.json,` you can set the custom properties there that will be loaded and indexed when the face of "Ilias" has been recognized. 

`FACE_DIR/Ilias/metadata.json` example file: 

```json
{
  "name": "Ilias Haddad",
  "alternate_names": ["Ilias Hadd"],
  "nationalities": ["Netherlands", "Morocco"],
  "date_of_birth": "1989-03-01",
  "place_of_birth": "Dordrecht, Netherlands",
  "height_m": 1.87,
  "positions": ["Centre-back"],
  "current_club": "Union Touarga",
  "club_jersey_number": 20,
  "dual_nationality": true
}
```

After the video is indexed, each video scene where "Ilias" has been recognized, this is how the video scene text document will be indexed and saved over the vector DB: 

`This is medium-shot shot featuring Ilias, Ilias (name: Ilias Haddad, alternate_names: Ilias Hadd, nationalities: Netherlands,Morocco, date_of_birth: 1989-03-01, place_of_birth: Dordrecht, Netherlands, height_m: 1.87, positions: Centre-back, current_club: Union Touarga, club_jersey_number: 20, dual_nationality: true`

Over the search page, you can search for that video scene using any attributes like ` current_club: Union Touarga` and it'll give back the video scene that we indexed. 


