### PR TITLE
Create a Helm Chart and local Kind setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ helm upgrade --install edit-mind ./charts/edit-mind \
   --namespace edit-mind \
   --create-namespace \
   --set media.hostPath="/media/videos" \
+  --set secrets.postgresPassword="$(openssl rand -hex 24)" \
   --set secrets.sessionSecret="$(openssl rand -hex 32)" \
   --set secrets.encryptionKey="$(openssl rand -base64 32)"
 ```

--- a/README.md
+++ b/README.md
@@ -182,6 +182,42 @@ Once all services are running (look for "ready" messages in logs):
 
 If you're using Safari, use [http://127.0.0.1:3745](http://127.0.0.1:3745)
 
+### Kubernetes with Helm and Kind
+
+This repository also includes a Helm chart at `charts/edit-mind` and a helper script for launching a local Kind cluster.
+
+Prerequisites:
+
+* Docker
+* [Kind](https://kind.sigs.k8s.io/)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/)
+* [Helm](https://helm.sh/)
+
+Run Edit Mind in a new or existing Kind cluster:
+
+```bash
+MEDIA_PATH="/path/to/your/media/folder" ./scripts/kind-deploy.sh
+```
+
+The script creates a Kind cluster named `edit-mind` when one does not already exist, mounts `MEDIA_PATH` into the Kind node, and installs the Helm chart into the `edit-mind` namespace. The web app is exposed at [http://localhost:3745](http://localhost:3745).
+
+You can pass extra Helm overrides after the script command:
+
+```bash
+MEDIA_PATH="/path/to/your/media/folder" ./scripts/kind-deploy.sh --set config.useGemini=true --set secrets.geminiApiKey="your-key"
+```
+
+To install the chart manually:
+
+```bash
+helm upgrade --install edit-mind ./charts/edit-mind \
+  --namespace edit-mind \
+  --create-namespace \
+  --set media.hostPath="/media/videos" \
+  --set secrets.sessionSecret="$(openssl rand -hex 32)" \
+  --set secrets.encryptionKey="$(openssl rand -base64 32)"
+```
+
 ### 6. Add Your First Videos
 
 1. Navigate to the web app at `http://localhost:3745`

--- a/charts/edit-mind/Chart.yaml
+++ b/charts/edit-mind/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: edit-mind
+description: A Helm chart for deploying Edit Mind and its backing services.
+type: application
+version: 0.1.0
+appVersion: "0.21.0"

--- a/charts/edit-mind/templates/NOTES.txt
+++ b/charts/edit-mind/templates/NOTES.txt
@@ -1,0 +1,6 @@
+Edit Mind has been installed.
+
+If you are using the default NodePort service, open:
+  http://localhost:30080
+
+For Kind clusters created with scripts/kind-deploy.sh, the script maps host port 3745 to that NodePort.

--- a/charts/edit-mind/templates/_helpers.tpl
+++ b/charts/edit-mind/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{- define "edit-mind.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "edit-mind.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "edit-mind.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "edit-mind.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "edit-mind.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "edit-mind.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "edit-mind.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "edit-mind.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/edit-mind/templates/configmap.yaml
+++ b/charts/edit-mind/templates/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-config
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+data:
+  POSTGRES_USER: {{ .Values.postgres.user | quote }}
+  POSTGRES_DB: {{ .Values.postgres.database | quote }}
+  PGDATA: /var/lib/postgresql/data/pgdata
+  REDIS_URL: redis://{{ include "edit-mind.fullname" . }}-redis:{{ .Values.redis.port }}
+  REDIS_HOST: {{ include "edit-mind.fullname" . }}-redis
+  CHROMA_HOST: {{ include "edit-mind.fullname" . }}-chroma
+  IS_PERSISTENT: "TRUE"
+  ML_HOST: {{ include "edit-mind.fullname" . }}-ml
+  ML_PORT: {{ .Values.ml.port | quote }}
+  PORT: {{ .Values.web.port | quote }}
+  BACKGROUND_JOBS_PORT: {{ .Values.backgroundJobs.port | quote }}
+  BACKGROUND_JOBS_URL: http://{{ include "edit-mind.fullname" . }}-background-jobs:{{ .Values.backgroundJobs.port }}
+  NODE_ENV: {{ .Values.config.nodeEnv | quote }}
+  ANONYMIZED_TELEMETRY: {{ .Values.config.anonymizedTelemetry | quote }}
+  WEB_APP_URL: http://{{ include "edit-mind.fullname" . }}-web:{{ .Values.web.port }}
+  PROCESSED_VIDEOS_DIR: /app/data
+  THUMBNAILS_PATH: /app/data/.thumbnails
+  STITCHED_VIDEOS_DIR: /app/data/.stitched-videos
+  FACES_DIR: /app/data/.faces
+  UNKNOWN_FACES_DIR: /app/data/.unknown_faces
+  KNOWN_FACES_FILE: /app/data/.faces.json
+  KNOWN_FACES_FILE_LOADED: /app/data/.known_faces.json
+  OLLAMA_MODEL: {{ .Values.config.ollamaModel | quote }}
+  USE_OLLAMA_MODEL: {{ .Values.config.useOllamaModel | quote }}
+  OLLAMA_HOST: {{ .Values.config.ollamaHost | quote }}
+  OLLAMA_PORT: {{ .Values.config.ollamaPort | quote }}
+  USE_GEMINI: {{ .Values.config.useGemini | quote }}

--- a/charts/edit-mind/templates/configmap.yaml
+++ b/charts/edit-mind/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
   PGDATA: /var/lib/postgresql/data/pgdata
   REDIS_URL: redis://{{ include "edit-mind.fullname" . }}-redis:{{ .Values.redis.port }}
   REDIS_HOST: {{ include "edit-mind.fullname" . }}-redis
+  REDIS_PORT: {{ .Values.redis.port | quote }}
   CHROMA_HOST: {{ include "edit-mind.fullname" . }}-chroma
   IS_PERSISTENT: "TRUE"
   ML_HOST: {{ include "edit-mind.fullname" . }}-ml
@@ -19,7 +20,7 @@ data:
   BACKGROUND_JOBS_URL: http://{{ include "edit-mind.fullname" . }}-background-jobs:{{ .Values.backgroundJobs.port }}
   NODE_ENV: {{ .Values.config.nodeEnv | quote }}
   ANONYMIZED_TELEMETRY: {{ .Values.config.anonymizedTelemetry | quote }}
-  WEB_APP_URL: http://{{ include "edit-mind.fullname" . }}-web:{{ .Values.web.port }}
+  WEB_APP_URL: {{ .Values.web.externalUrl | default (printf "http://%s-web:%v" (include "edit-mind.fullname" .) .Values.web.port) | quote }}
   PROCESSED_VIDEOS_DIR: /app/data
   THUMBNAILS_PATH: /app/data/.thumbnails
   STITCHED_VIDEOS_DIR: /app/data/.stitched-videos

--- a/charts/edit-mind/templates/deployments.yaml
+++ b/charts/edit-mind/templates/deployments.yaml
@@ -32,6 +32,7 @@ spec:
           volumeMounts:
             - name: media
               mountPath: {{ .Values.media.mountPath | quote }}
+              readOnly: {{ .Values.media.backgroundJobsReadOnly }}
               readOnly: true
             - name: data
               mountPath: /app/data

--- a/charts/edit-mind/templates/deployments.yaml
+++ b/charts/edit-mind/templates/deployments.yaml
@@ -73,11 +73,18 @@ spec:
     spec:
       containers:
         - name: background-jobs
-          image: "{{ .Values.backgroundJobs.image.repository }}:{{ .Values.backgroundJobs.image.tag }}"
+          image: "{{ .Values.backgroundJobs.image.repository }}:{{ .Values.backgroundJobs.image.tag }}{{ if and .Values.gpu.enabled .Values.gpu.backgroundJobs.enabled }}{{ .Values.gpu.imageTagSuffix }}{{ end }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.backgroundJobs.port }}
+          {{- if and .Values.gpu.enabled .Values.gpu.backgroundJobs.enabled }}
+          env:
+            {{- range $k, $v := .Values.gpu.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "edit-mind.fullname" . }}-config
@@ -92,7 +99,12 @@ spec:
             - name: ml-models
               mountPath: /app/ml-models
           resources:
+            {{- if and .Values.gpu.enabled .Values.gpu.backgroundJobs.enabled }}
+            limits:
+              {{ .Values.gpu.resourceName }}: {{ .Values.gpu.backgroundJobs.count }}
+            {{- else }}
             {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
       volumes:
         - name: media
           hostPath:
@@ -126,7 +138,7 @@ spec:
     spec:
       containers:
         - name: ml
-          image: "{{ .Values.ml.image.repository }}:{{ .Values.ml.image.tag }}"
+          image: "{{ .Values.ml.image.repository }}:{{ .Values.ml.image.tag }}{{ if and .Values.gpu.enabled .Values.gpu.ml.enabled }}{{ .Values.gpu.imageTagSuffix }}{{ end }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - name: http
@@ -142,6 +154,12 @@ spec:
               value: /ml-models/torch
             - name: HF_HOME
               value: /ml-models/huggingface
+            {{- if and .Values.gpu.enabled .Values.gpu.ml.enabled }}
+            {{- range $k, $v := .Values.gpu.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "edit-mind.fullname" . }}-config
@@ -156,7 +174,12 @@ spec:
             - name: ml-models
               mountPath: /ml-models
           resources:
+            {{- if and .Values.gpu.enabled .Values.gpu.ml.enabled }}
+            limits:
+              {{ .Values.gpu.resourceName }}: {{ .Values.gpu.ml.count }}
+            {{- else }}
             {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
       volumes:
         - name: media
           hostPath:

--- a/charts/edit-mind/templates/deployments.yaml
+++ b/charts/edit-mind/templates/deployments.yaml
@@ -1,0 +1,169 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-web
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "edit-mind.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "edit-mind.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      containers:
+        - name: web
+          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "edit-mind.fullname" . }}-config
+            - secretRef:
+                name: {{ include "edit-mind.secretName" . }}
+          volumeMounts:
+            - name: media
+              mountPath: /media/videos
+              readOnly: true
+            - name: data
+              mountPath: /app/data
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: media
+          hostPath:
+            path: {{ .Values.media.hostPath | quote }}
+            type: DirectoryOrCreate
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "edit-mind.fullname" . }}-data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-background-jobs
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: background-jobs
+spec:
+  replicas: {{ .Values.backgroundJobs.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "edit-mind.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: background-jobs
+  template:
+    metadata:
+      labels:
+        {{- include "edit-mind.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: background-jobs
+    spec:
+      containers:
+        - name: background-jobs
+          image: "{{ .Values.backgroundJobs.image.repository }}:{{ .Values.backgroundJobs.image.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.backgroundJobs.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "edit-mind.fullname" . }}-config
+            - secretRef:
+                name: {{ include "edit-mind.secretName" . }}
+          volumeMounts:
+            - name: media
+              mountPath: /media/videos
+            - name: data
+              mountPath: /app/data
+            - name: ml-models
+              mountPath: /app/ml-models
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: media
+          hostPath:
+            path: {{ .Values.media.hostPath | quote }}
+            type: DirectoryOrCreate
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "edit-mind.fullname" . }}-data
+        - name: ml-models
+          persistentVolumeClaim:
+            claimName: {{ include "edit-mind.fullname" . }}-mlModels
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-ml
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ml
+spec:
+  replicas: {{ .Values.ml.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "edit-mind.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ml
+  template:
+    metadata:
+      labels:
+        {{- include "edit-mind.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ml
+    spec:
+      containers:
+        - name: ml
+          image: "{{ .Values.ml.image.repository }}:{{ .Values.ml.image.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ml.port }}
+          env:
+            - name: YOLO_CONFIG_DIR
+              value: /ml-models/ultralytics
+            - name: DEEPFACE_HOME
+              value: /ml-models/deepface
+            - name: TRANSCRIPTION_MODEL_CACHE
+              value: /ml-models/whisper
+            - name: TORCH_HOME
+              value: /ml-models/torch
+            - name: HF_HOME
+              value: /ml-models/huggingface
+          envFrom:
+            - configMapRef:
+                name: {{ include "edit-mind.fullname" . }}-config
+            - secretRef:
+                name: {{ include "edit-mind.secretName" . }}
+          volumeMounts:
+            - name: media
+              mountPath: /media/videos
+              readOnly: true
+            - name: data
+              mountPath: /app/data
+            - name: ml-models
+              mountPath: /ml-models
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: media
+          hostPath:
+            path: {{ .Values.media.hostPath | quote }}
+            type: DirectoryOrCreate
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "edit-mind.fullname" . }}-data
+        - name: ml-models
+          persistentVolumeClaim:
+            claimName: {{ include "edit-mind.fullname" . }}-mlModels

--- a/charts/edit-mind/templates/deployments.yaml
+++ b/charts/edit-mind/templates/deployments.yaml
@@ -31,7 +31,7 @@ spec:
                 name: {{ include "edit-mind.secretName" . }}
           volumeMounts:
             - name: media
-              mountPath: /media/videos
+              mountPath: {{ .Values.media.mountPath | quote }}
               readOnly: true
             - name: data
               mountPath: /app/data
@@ -85,7 +85,7 @@ spec:
                 name: {{ include "edit-mind.secretName" . }}
           volumeMounts:
             - name: media
-              mountPath: /media/videos
+              mountPath: {{ .Values.media.mountPath | quote }}
             - name: data
               mountPath: /app/data
             - name: ml-models
@@ -148,7 +148,7 @@ spec:
                 name: {{ include "edit-mind.secretName" . }}
           volumeMounts:
             - name: media
-              mountPath: /media/videos
+              mountPath: {{ .Values.media.mountPath | quote }}
               readOnly: true
             - name: data
               mountPath: /app/data

--- a/charts/edit-mind/templates/deployments.yaml
+++ b/charts/edit-mind/templates/deployments.yaml
@@ -32,7 +32,6 @@ spec:
           volumeMounts:
             - name: media
               mountPath: {{ .Values.media.mountPath | quote }}
-              readOnly: {{ .Values.media.backgroundJobsReadOnly }}
               readOnly: true
             - name: data
               mountPath: /app/data
@@ -87,6 +86,7 @@ spec:
           volumeMounts:
             - name: media
               mountPath: {{ .Values.media.mountPath | quote }}
+              readOnly: {{ .Values.media.backgroundJobsReadOnly }}
             - name: data
               mountPath: /app/data
             - name: ml-models

--- a/charts/edit-mind/templates/deployments.yaml
+++ b/charts/edit-mind/templates/deployments.yaml
@@ -102,7 +102,7 @@ spec:
             claimName: {{ include "edit-mind.fullname" . }}-data
         - name: ml-models
           persistentVolumeClaim:
-            claimName: {{ include "edit-mind.fullname" . }}-mlModels
+            claimName: {{ include "edit-mind.fullname" . }}-ml-models
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -166,4 +166,4 @@ spec:
             claimName: {{ include "edit-mind.fullname" . }}-data
         - name: ml-models
           persistentVolumeClaim:
-            claimName: {{ include "edit-mind.fullname" . }}-mlModels
+            claimName: {{ include "edit-mind.fullname" . }}-ml-models

--- a/charts/edit-mind/templates/pvcs.yaml
+++ b/charts/edit-mind/templates/pvcs.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "edit-mind.fullname" $ }}-{{ $name | kebabcase }}
+  name: {{ include "edit-mind.fullname" $ }}-{{ $name }}
   labels:
     {{- include "edit-mind.labels" $ | nindent 4 }}
 spec:

--- a/charts/edit-mind/templates/pvcs.yaml
+++ b/charts/edit-mind/templates/pvcs.yaml
@@ -1,0 +1,15 @@
+{{- range $name, $cfg := .Values.persistence }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "edit-mind.fullname" $ }}-{{ $name }}
+  labels:
+    {{- include "edit-mind.labels" $ | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ $cfg.size }}
+---
+{{- end }}

--- a/charts/edit-mind/templates/pvcs.yaml
+++ b/charts/edit-mind/templates/pvcs.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "edit-mind.fullname" $ }}-{{ $name }}
+  name: {{ include "edit-mind.fullname" $ }}-{{ $name | kebabcase }}
   labels:
     {{- include "edit-mind.labels" $ | nindent 4 }}
 spec:

--- a/charts/edit-mind/templates/secret.yaml
+++ b/charts/edit-mind/templates/secret.yaml
@@ -10,6 +10,6 @@ stringData:
   SESSION_SECRET: {{ .Values.secrets.sessionSecret | quote }}
   ENCRYPTION_KEY: {{ .Values.secrets.encryptionKey | quote }}
   POSTGRES_PASSWORD: {{ .Values.secrets.postgresPassword | quote }}
-  DATABASE_URL: {{ printf "postgresql://%s:%s@%s-postgres:%v/%s" .Values.postgres.user .Values.secrets.postgresPassword (include "edit-mind.fullname" .) .Values.postgres.port .Values.postgres.database | quote }}
+  DATABASE_URL: {{ printf "postgresql://%s:%s@%s-postgres:%v/%s" .Values.postgres.user (.Values.secrets.postgresPassword | urlquery) (include "edit-mind.fullname" .) .Values.postgres.port .Values.postgres.database | quote }}
   GEMINI_API_KEY: {{ .Values.secrets.geminiApiKey | quote }}
 {{- end }}

--- a/charts/edit-mind/templates/secret.yaml
+++ b/charts/edit-mind/templates/secret.yaml
@@ -1,4 +1,8 @@
 {{- if and .Values.secrets.create (not .Values.secrets.existingSecret) }}
+{{- $postgresPassword := required "secrets.postgresPassword is required when secrets.create is true" .Values.secrets.postgresPassword -}}
+{{- if not (regexMatch "^[A-Za-z0-9._~-]+$" $postgresPassword) -}}
+{{- fail "secrets.postgresPassword must contain only URL-safe characters: letters, numbers, '.', '_', '~', and '-'" -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +13,7 @@ type: Opaque
 stringData:
   SESSION_SECRET: {{ .Values.secrets.sessionSecret | quote }}
   ENCRYPTION_KEY: {{ .Values.secrets.encryptionKey | quote }}
-  POSTGRES_PASSWORD: {{ .Values.secrets.postgresPassword | quote }}
-  DATABASE_URL: {{ printf "postgresql://%s:%s@%s-postgres:%v/%s" .Values.postgres.user (.Values.secrets.postgresPassword | urlquery) (include "edit-mind.fullname" .) .Values.postgres.port .Values.postgres.database | quote }}
+  POSTGRES_PASSWORD: {{ $postgresPassword | quote }}
+  DATABASE_URL: {{ printf "postgresql://%s:%s@%s-postgres:%v/%s" .Values.postgres.user $postgresPassword (include "edit-mind.fullname" .) .Values.postgres.port .Values.postgres.database | quote }}
   GEMINI_API_KEY: {{ .Values.secrets.geminiApiKey | quote }}
 {{- end }}

--- a/charts/edit-mind/templates/secret.yaml
+++ b/charts/edit-mind/templates/secret.yaml
@@ -1,8 +1,6 @@
 {{- if and .Values.secrets.create (not .Values.secrets.existingSecret) }}
 {{- $postgresPassword := required "secrets.postgresPassword is required when secrets.create is true" .Values.secrets.postgresPassword -}}
-{{- if not (regexMatch "^[A-Za-z0-9._~-]+$" $postgresPassword) -}}
-{{- fail "secrets.postgresPassword must contain only URL-safe characters: letters, numbers, '.', '_', '~', and '-'" -}}
-{{- end -}}
+{{- $databaseUrlPassword := $postgresPassword | urlquery | replace "+" "%20" -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,6 +12,6 @@ stringData:
   SESSION_SECRET: {{ .Values.secrets.sessionSecret | quote }}
   ENCRYPTION_KEY: {{ .Values.secrets.encryptionKey | quote }}
   POSTGRES_PASSWORD: {{ $postgresPassword | quote }}
-  DATABASE_URL: {{ printf "postgresql://%s:%s@%s-postgres:%v/%s" .Values.postgres.user $postgresPassword (include "edit-mind.fullname" .) .Values.postgres.port .Values.postgres.database | quote }}
+  DATABASE_URL: {{ printf "postgresql://%s:%s@%s-postgres:%v/%s" .Values.postgres.user $databaseUrlPassword (include "edit-mind.fullname" .) .Values.postgres.port .Values.postgres.database | quote }}
   GEMINI_API_KEY: {{ .Values.secrets.geminiApiKey | quote }}
 {{- end }}

--- a/charts/edit-mind/templates/secret.yaml
+++ b/charts/edit-mind/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.secrets.create (not .Values.secrets.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "edit-mind.secretName" . }}
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  SESSION_SECRET: {{ .Values.secrets.sessionSecret | quote }}
+  ENCRYPTION_KEY: {{ .Values.secrets.encryptionKey | quote }}
+  POSTGRES_PASSWORD: {{ .Values.secrets.postgresPassword | quote }}
+  DATABASE_URL: {{ printf "postgresql://%s:%s@%s-postgres:%v/%s" .Values.postgres.user .Values.secrets.postgresPassword (include "edit-mind.fullname" .) .Values.postgres.port .Values.postgres.database | quote }}
+  GEMINI_API_KEY: {{ .Values.secrets.geminiApiKey | quote }}
+{{- end }}

--- a/charts/edit-mind/templates/services.yaml
+++ b/charts/edit-mind/templates/services.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-web
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.web.service.type }}
+  selector:
+    {{- include "edit-mind.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  ports:
+    - name: http
+      port: {{ .Values.web.port }}
+      targetPort: http
+      {{- if and (eq .Values.web.service.type "NodePort") .Values.web.service.nodePort }}
+      nodePort: {{ .Values.web.service.nodePort }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-background-jobs
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "edit-mind.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: background-jobs
+  ports:
+    - name: http
+      port: {{ .Values.backgroundJobs.port }}
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-ml
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "edit-mind.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ml
+  ports:
+    - name: http
+      port: {{ .Values.ml.port }}
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-chroma
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "edit-mind.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: chroma
+  ports:
+    - name: http
+      port: {{ .Values.chroma.port }}
+      targetPort: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-redis
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "edit-mind.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+  ports:
+    - name: redis
+      port: {{ .Values.redis.port }}
+      targetPort: redis
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-postgres
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "edit-mind.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+  ports:
+    - name: postgres
+      port: {{ .Values.postgres.port }}
+      targetPort: postgres

--- a/charts/edit-mind/templates/services.yaml
+++ b/charts/edit-mind/templates/services.yaml
@@ -24,6 +24,7 @@ metadata:
   labels:
     {{- include "edit-mind.labels" . | nindent 4 }}
 spec:
+  type: {{ .Values.backgroundJobs.service.type }}
   selector:
     {{- include "edit-mind.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: background-jobs
@@ -31,6 +32,9 @@ spec:
     - name: http
       port: {{ .Values.backgroundJobs.port }}
       targetPort: http
+      {{- if and (eq .Values.backgroundJobs.service.type "NodePort") .Values.backgroundJobs.service.nodePort }}
+      nodePort: {{ .Values.backgroundJobs.service.nodePort }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/edit-mind/templates/statefulsets.yaml
+++ b/charts/edit-mind/templates/statefulsets.yaml
@@ -1,0 +1,147 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-chroma
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: chroma
+spec:
+  serviceName: {{ include "edit-mind.fullname" . }}-chroma
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "edit-mind.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: chroma
+  template:
+    metadata:
+      labels:
+        {{- include "edit-mind.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: chroma
+    spec:
+      containers:
+        - name: chroma
+          image: "{{ .Values.chroma.image.repository }}:{{ .Values.chroma.image.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.chroma.port }}
+          env:
+            - name: IS_PERSISTENT
+              value: "TRUE"
+            - name: CHROMA_CORS_ALLOW_ORIGINS
+              value: {{ .Values.chroma.corsAllowOrigins | quote }}
+          volumeMounts:
+            - name: chroma
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: chroma
+          persistentVolumeClaim:
+            claimName: {{ include "edit-mind.fullname" . }}-chroma
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-redis
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  serviceName: {{ include "edit-mind.fullname" . }}-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "edit-mind.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "edit-mind.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - name: redis
+              containerPort: {{ .Values.redis.port }}
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            periodSeconds: 5
+          volumeMounts:
+            - name: redis
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: redis
+          persistentVolumeClaim:
+            claimName: {{ include "edit-mind.fullname" . }}-redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "edit-mind.fullname" . }}-postgres
+  labels:
+    {{- include "edit-mind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: {{ include "edit-mind.fullname" . }}-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "edit-mind.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "edit-mind.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.postgres.port }}
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "edit-mind.fullname" . }}-config
+                  key: POSTGRES_USER
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "edit-mind.fullname" . }}-config
+                  key: POSTGRES_DB
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "edit-mind.secretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "edit-mind.fullname" . }}-config
+                  key: PGDATA
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            periodSeconds: 5
+          volumeMounts:
+            - name: postgres
+              mountPath: /var/lib/postgresql/data
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: postgres
+          persistentVolumeClaim:
+            claimName: {{ include "edit-mind.fullname" . }}-postgres

--- a/charts/edit-mind/values.yaml
+++ b/charts/edit-mind/values.yaml
@@ -9,6 +9,9 @@ web:
     tag: latest
   port: 3745
   replicaCount: 1
+  # Browser-facing URL used as the CORS origin allowed by background-jobs.
+  # Must match the host:port the user opens in their browser.
+  externalUrl: ""
   service:
     type: NodePort
     nodePort: 30080
@@ -19,6 +22,9 @@ backgroundJobs:
     tag: latest
   port: 4000
   replicaCount: 1
+  service:
+    type: NodePort
+    nodePort: 30040
 
 ml:
   image:
@@ -85,3 +91,22 @@ persistence:
     size: 10Gi
 
 resources: {}
+
+# GPU access is granted per component. `gpu.enabled` is the master switch and
+# also controls cluster-side setup (NVIDIA device plugin install in
+# scripts/kind-deploy.sh). A component gets a GPU only when both
+# `gpu.enabled` and `gpu.<component>.enabled` are true. Requires the NVIDIA
+# device plugin in the cluster.
+gpu:
+  enabled: false
+  resourceName: nvidia.com/gpu
+  imageTagSuffix: "-gpu"
+  env:
+    NVIDIA_VISIBLE_DEVICES: all
+    NVIDIA_DRIVER_CAPABILITIES: compute,utility
+  ml:
+    enabled: true
+    count: 1
+  backgroundJobs:
+    enabled: false
+    count: 1

--- a/charts/edit-mind/values.yaml
+++ b/charts/edit-mind/values.yaml
@@ -1,0 +1,83 @@
+nameOverride: ""
+fullnameOverride: ""
+
+imagePullPolicy: IfNotPresent
+
+web:
+  image:
+    repository: ghcr.io/iliashad/edit-mind-web
+    tag: latest
+  port: 3745
+  replicaCount: 1
+  service:
+    type: NodePort
+    nodePort: 30080
+
+backgroundJobs:
+  image:
+    repository: ghcr.io/iliashad/edit-mind-background-jobs
+    tag: latest
+  port: 4000
+  replicaCount: 1
+
+ml:
+  image:
+    repository: ghcr.io/iliashad/edit-mind-ml
+    tag: latest
+  port: 8765
+  replicaCount: 1
+
+chroma:
+  image:
+    repository: chromadb/chroma
+    tag: 1.3.5
+  port: 8000
+  corsAllowOrigins: '["http://localhost:3745", "http://localhost:4000", "http://web:3745", "http://background-jobs:4000"]'
+
+redis:
+  image:
+    repository: redis
+    tag: "7"
+  port: 6379
+
+postgres:
+  image:
+    repository: postgres
+    tag: 16-alpine
+  port: 5432
+  user: user
+  database: app
+
+config:
+  nodeEnv: production
+  anonymizedTelemetry: "FALSE"
+  useOllamaModel: "false"
+  ollamaHost: ""
+  ollamaPort: ""
+  ollamaModel: qwen2.5:7b-instruct
+  useGemini: "false"
+
+secrets:
+  create: true
+  existingSecret: ""
+  sessionSecret: ""
+  encryptionKey: ""
+  postgresPassword: password
+  geminiApiKey: ""
+
+media:
+  hostPath: /media/videos
+
+persistence:
+  data:
+    size: 10Gi
+  chroma:
+    size: 10Gi
+  redis:
+    size: 1Gi
+  postgres:
+    size: 10Gi
+  mlModels:
+    size: 10Gi
+
+resources: {}

--- a/charts/edit-mind/values.yaml
+++ b/charts/edit-mind/values.yaml
@@ -62,11 +62,13 @@ secrets:
   existingSecret: ""
   sessionSecret: ""
   encryptionKey: ""
+  # Development default for local installs. Override for any shared or production cluster.
   postgresPassword: password
   geminiApiKey: ""
 
 media:
   hostPath: /media/videos
+  mountPath: /media/videos
 
 persistence:
   data:

--- a/charts/edit-mind/values.yaml
+++ b/charts/edit-mind/values.yaml
@@ -79,7 +79,7 @@ persistence:
     size: 1Gi
   postgres:
     size: 10Gi
-  mlModels:
+  ml-models:
     size: 10Gi
 
 resources: {}

--- a/charts/edit-mind/values.yaml
+++ b/charts/edit-mind/values.yaml
@@ -62,13 +62,15 @@ secrets:
   existingSecret: ""
   sessionSecret: ""
   encryptionKey: ""
-  # Development default for local installs. Override for any shared or production cluster.
-  postgresPassword: password
+  # Required unless existingSecret is set. Use URL-safe characters: letters, numbers, '.', '_', '~', and '-'.
+  postgresPassword: ""
   geminiApiKey: ""
 
 media:
   hostPath: /media/videos
   mountPath: /media/videos
+  # Mirrors docker-compose.yml, where background-jobs gets read-write media access.
+  backgroundJobsReadOnly: false
 
 persistence:
   data:

--- a/charts/edit-mind/values.yaml
+++ b/charts/edit-mind/values.yaml
@@ -62,7 +62,7 @@ secrets:
   existingSecret: ""
   sessionSecret: ""
   encryptionKey: ""
-  # Required unless existingSecret is set. Use URL-safe characters: letters, numbers, '.', '_', '~', and '-'.
+  # Required unless existingSecret is set.
   postgresPassword: ""
   geminiApiKey: ""
 

--- a/scripts/kind-deploy.sh
+++ b/scripts/kind-deploy.sh
@@ -57,7 +57,9 @@ reuse_secret_value() {
 
   encoded="$(kubectl -n "${NAMESPACE}" get secret "${secret_name}" -o "jsonpath={.data.${key}}" 2>/dev/null || true)"
   if [ -n "${encoded}" ]; then
-    printf '%s' "${encoded}" | base64 --decode 2>/dev/null || printf '%s' "${encoded}" | base64 -D
+    if ! printf '%s' "${encoded}" | base64 --decode 2>/dev/null; then
+      printf '%s' "${encoded}" | base64 -D
+    fi
   fi
 }
 

--- a/scripts/kind-deploy.sh
+++ b/scripts/kind-deploy.sh
@@ -10,6 +10,16 @@ MEDIA_PATH="${MEDIA_PATH:-${ROOT_DIR}/media}"
 NODE_MEDIA_PATH="${KIND_NODE_MEDIA_PATH:-/media/videos}"
 WEB_PORT="${WEB_PORT:-3745}"
 NODE_PORT="${NODE_PORT:-30080}"
+BACKGROUND_JOBS_HOST_PORT="${BACKGROUND_JOBS_HOST_PORT:-4000}"
+BACKGROUND_JOBS_NODE_PORT="${BACKGROUND_JOBS_NODE_PORT:-30040}"
+REGISTRY_CACHE_DIR="${REGISTRY_CACHE_DIR:-${HOME}/.kind-registry-cache}"
+DOCKERHUB_MIRROR_NAME="${DOCKERHUB_MIRROR_NAME:-kind-registry-dockerhub}"
+GHCR_MIRROR_NAME="${GHCR_MIRROR_NAME:-kind-registry-ghcr}"
+DOCKERHUB_MIRROR_HOST_PORT="${DOCKERHUB_MIRROR_HOST_PORT:-5001}"
+GHCR_MIRROR_HOST_PORT="${GHCR_MIRROR_HOST_PORT:-5002}"
+GPU_ENABLED="${GPU_ENABLED:-auto}"
+NVIDIA_DEVICE_PLUGIN_VERSION="${NVIDIA_DEVICE_PLUGIN_VERSION:-v0.17.0}"
+CONTAINERD_PERSIST_DIR="${CONTAINERD_PERSIST_DIR:-${HOME}/.kind-containerd-cache/${CLUSTER_NAME}}"
 POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-}"
 SESSION_SECRET="${SESSION_SECRET:-}"
 ENCRYPTION_KEY="${ENCRYPTION_KEY:-}"
@@ -50,6 +60,38 @@ chart_fullname() {
   fi
 }
 
+ensure_registry_mirror() {
+  local name="$1"
+  local host_port="$2"
+  local upstream="$3"
+  local data_dir="${REGISTRY_CACHE_DIR}/${name}"
+
+  mkdir -p "${data_dir}"
+
+  if [ "$(docker inspect -f '{{.State.Running}}' "${name}" 2>/dev/null)" = "true" ]; then
+    return
+  fi
+
+  docker rm -f "${name}" >/dev/null 2>&1 || true
+  docker run -d --restart=always \
+    --name "${name}" \
+    -e REGISTRY_PROXY_REMOTEURL="${upstream}" \
+    -v "${data_dir}:/var/lib/registry" \
+    -p "127.0.0.1:${host_port}:5000" \
+    registry:2 >/dev/null
+}
+
+connect_mirror_to_kind_network() {
+  local name="$1"
+  if ! docker network inspect kind >/dev/null 2>&1; then
+    return
+  fi
+  if docker network inspect kind --format '{{range .Containers}}{{.Name}} {{end}}' | grep -qw "${name}"; then
+    return
+  fi
+  docker network connect kind "${name}"
+}
+
 reuse_secret_value() {
   local secret_name="$1"
   local key="$2"
@@ -76,21 +118,53 @@ if [ ! -d "${MEDIA_PATH_REAL}" ] || [ ! -r "${MEDIA_PATH_REAL}" ]; then
   exit 1
 fi
 
+ensure_registry_mirror "${DOCKERHUB_MIRROR_NAME}" "${DOCKERHUB_MIRROR_HOST_PORT}" "https://registry-1.docker.io"
+ensure_registry_mirror "${GHCR_MIRROR_NAME}" "${GHCR_MIRROR_HOST_PORT}" "https://ghcr.io"
+
+mkdir -p "${CONTAINERD_PERSIST_DIR}"
+
+if [ "${GPU_ENABLED}" = "auto" ]; then
+  if docker info 2>/dev/null | grep -q '^ Default Runtime: nvidia'; then
+    GPU_ENABLED="true"
+  else
+    GPU_ENABLED="false"
+  fi
+fi
+
+GPU_CONTAINERD_PATCH=""
+GPU_EXTRA_MOUNTS=""
+if [ "${GPU_ENABLED}" = "true" ]; then
+  GPU_CONTAINERD_PATCH=$'  - |-\n    [plugins."io.containerd.grpc.v1.cri".containerd]\n      default_runtime_name = "nvidia"\n    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]\n      runtime_type = "io.containerd.runc.v2"\n    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]\n      BinaryName = "/usr/bin/nvidia-container-runtime"\n      SystemdCgroup = true'
+  GPU_EXTRA_MOUNTS=$'\n      - hostPath: /usr/bin/nvidia-container-runtime\n        containerPath: /usr/bin/nvidia-container-runtime\n      - hostPath: /usr/bin/nvidia-container-runtime-hook\n        containerPath: /usr/bin/nvidia-container-runtime-hook\n      - hostPath: /usr/bin/nvidia-ctk\n        containerPath: /usr/bin/nvidia-ctk\n      - hostPath: /dev/null\n        containerPath: /var/run/nvidia-container-devices/all'
+fi
+
 KIND_CONFIG="$(mktemp)"
 trap 'rm -f "${KIND_CONFIG}"' EXIT
 
 cat > "${KIND_CONFIG}" <<CONFIG
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+      endpoint = ["http://${DOCKERHUB_MIRROR_NAME}:5000"]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
+      endpoint = ["http://${GHCR_MIRROR_NAME}:5000"]
+${GPU_CONTAINERD_PATCH}
 nodes:
   - role: control-plane
     extraPortMappings:
       - containerPort: ${NODE_PORT}
         hostPort: ${WEB_PORT}
         protocol: TCP
+      - containerPort: ${BACKGROUND_JOBS_NODE_PORT}
+        hostPort: ${BACKGROUND_JOBS_HOST_PORT}
+        protocol: TCP
     extraMounts:
       - hostPath: ${MEDIA_PATH_REAL}
         containerPath: ${NODE_MEDIA_PATH}
+      - hostPath: ${CONTAINERD_PERSIST_DIR}
+        containerPath: /var/lib/containerd${GPU_EXTRA_MOUNTS}
 CONFIG
 
 if ! kind get clusters | grep -qx "${CLUSTER_NAME}"; then
@@ -98,6 +172,14 @@ if ! kind get clusters | grep -qx "${CLUSTER_NAME}"; then
 else
   echo "Using existing Kind cluster '${CLUSTER_NAME}'."
   echo "Ensure it was created with host port ${WEB_PORT}->${NODE_PORT} and media mount ${MEDIA_PATH_REAL}->${NODE_MEDIA_PATH}."
+fi
+
+connect_mirror_to_kind_network "${DOCKERHUB_MIRROR_NAME}"
+connect_mirror_to_kind_network "${GHCR_MIRROR_NAME}"
+
+if [ "${GPU_ENABLED}" = "true" ]; then
+  echo "GPU enabled: installing NVIDIA device plugin (${NVIDIA_DEVICE_PLUGIN_VERSION})."
+  kubectl apply -f "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/${NVIDIA_DEVICE_PLUGIN_VERSION}/deployments/static/nvidia-device-plugin.yml"
 fi
 
 kubectl config use-context "kind-${CLUSTER_NAME}"
@@ -117,6 +199,9 @@ helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}" \
   --set media.mountPath="${NODE_MEDIA_PATH}" \
   --set web.port="${WEB_PORT}" \
   --set web.service.nodePort="${NODE_PORT}" \
+  --set web.externalUrl="http://localhost:${WEB_PORT}" \
+  --set backgroundJobs.service.nodePort="${BACKGROUND_JOBS_NODE_PORT}" \
+  --set gpu.enabled="${GPU_ENABLED}" \
   --set secrets.postgresPassword="${POSTGRES_PASSWORD}" \
   --set secrets.sessionSecret="${SESSION_SECRET}" \
   --set secrets.encryptionKey="${ENCRYPTION_KEY}" \

--- a/scripts/kind-deploy.sh
+++ b/scripts/kind-deploy.sh
@@ -26,16 +26,19 @@ require_command kind
 require_command kubectl
 require_command helm
 require_command openssl
+require_command realpath
 
-case "$(cd "$(dirname "${MEDIA_PATH}")" && pwd)/$(basename "${MEDIA_PATH}")" in
-  /|/bin|/boot|/dev|/etc|/lib|/lib64|/proc|/root|/run|/sbin|/sys|/usr|/var)
+mkdir -p "${MEDIA_PATH}"
+MEDIA_PATH_REAL="$(realpath "${MEDIA_PATH}")"
+
+case "${MEDIA_PATH_REAL}" in
+  /|/bin|/bin/*|/boot|/boot/*|/dev|/dev/*|/etc|/etc/*|/lib|/lib/*|/lib64|/lib64/*|/proc|/proc/*|/root|/root/*|/run|/run/*|/sbin|/sbin/*|/sys|/sys/*|/usr|/usr/*|/var|/var/*)
     echo "MEDIA_PATH points to a system directory. Choose a dedicated media directory." >&2
     exit 1
     ;;
 esac
 
-mkdir -p "${MEDIA_PATH}"
-if [ ! -d "${MEDIA_PATH}" ] || [ ! -r "${MEDIA_PATH}" ]; then
+if [ ! -d "${MEDIA_PATH_REAL}" ] || [ ! -r "${MEDIA_PATH_REAL}" ]; then
   echo "MEDIA_PATH must be a readable directory: ${MEDIA_PATH}" >&2
   exit 1
 fi
@@ -53,7 +56,7 @@ nodes:
         hostPort: ${WEB_PORT}
         protocol: TCP
     extraMounts:
-      - hostPath: ${MEDIA_PATH}
+      - hostPath: ${MEDIA_PATH_REAL}
         containerPath: ${NODE_MEDIA_PATH}
 CONFIG
 
@@ -81,7 +84,7 @@ cat <<MESSAGE
 
 Edit Mind is being deployed to Kind cluster '${CLUSTER_NAME}'.
 
-Media directory: ${MEDIA_PATH}
+Media directory: ${MEDIA_PATH_REAL}
 Namespace: ${NAMESPACE}
 Release: ${RELEASE_NAME}
 URL: http://localhost:${WEB_PORT}

--- a/scripts/kind-deploy.sh
+++ b/scripts/kind-deploy.sh
@@ -10,9 +10,9 @@ MEDIA_PATH="${MEDIA_PATH:-${ROOT_DIR}/media}"
 NODE_MEDIA_PATH="${KIND_NODE_MEDIA_PATH:-/media/videos}"
 WEB_PORT="${WEB_PORT:-3745}"
 NODE_PORT="${NODE_PORT:-30080}"
-POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-$(openssl rand -hex 24)}"
-SESSION_SECRET="${SESSION_SECRET:-$(openssl rand -hex 32)}"
-ENCRYPTION_KEY="${ENCRYPTION_KEY:-$(openssl rand -base64 32)}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-}"
+SESSION_SECRET="${SESSION_SECRET:-}"
+ENCRYPTION_KEY="${ENCRYPTION_KEY:-}"
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -27,6 +27,7 @@ require_command kubectl
 require_command helm
 require_command openssl
 require_command realpath
+require_command base64
 
 is_system_path() {
   local path="$1"
@@ -39,6 +40,25 @@ is_system_path() {
   done
 
   return 1
+}
+
+chart_fullname() {
+  if [[ "${RELEASE_NAME}" == *edit-mind* ]]; then
+    printf '%s' "${RELEASE_NAME}"
+  else
+    printf '%s-edit-mind' "${RELEASE_NAME}"
+  fi
+}
+
+reuse_secret_value() {
+  local secret_name="$1"
+  local key="$2"
+  local encoded
+
+  encoded="$(kubectl -n "${NAMESPACE}" get secret "${secret_name}" -o "jsonpath={.data.${key}}" 2>/dev/null || true)"
+  if [ -n "${encoded}" ]; then
+    printf '%s' "${encoded}" | base64 --decode 2>/dev/null || printf '%s' "${encoded}" | base64 -D
+  fi
 }
 
 mkdir -p "${MEDIA_PATH}"
@@ -75,10 +95,19 @@ if ! kind get clusters | grep -qx "${CLUSTER_NAME}"; then
   kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}"
 else
   echo "Using existing Kind cluster '${CLUSTER_NAME}'."
+  echo "Ensure it was created with host port ${WEB_PORT}->${NODE_PORT} and media mount ${MEDIA_PATH_REAL}->${NODE_MEDIA_PATH}."
 fi
 
 kubectl config use-context "kind-${CLUSTER_NAME}"
 kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+SECRET_NAME="$(chart_fullname)-secrets"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-$(reuse_secret_value "${SECRET_NAME}" POSTGRES_PASSWORD)}"
+SESSION_SECRET="${SESSION_SECRET:-$(reuse_secret_value "${SECRET_NAME}" SESSION_SECRET)}"
+ENCRYPTION_KEY="${ENCRYPTION_KEY:-$(reuse_secret_value "${SECRET_NAME}" ENCRYPTION_KEY)}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-$(openssl rand -hex 24)}"
+SESSION_SECRET="${SESSION_SECRET:-$(openssl rand -hex 32)}"
+ENCRYPTION_KEY="${ENCRYPTION_KEY:-$(openssl rand -base64 32)}"
 
 helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}" \
   --namespace "${NAMESPACE}" \

--- a/scripts/kind-deploy.sh
+++ b/scripts/kind-deploy.sh
@@ -27,7 +27,19 @@ require_command kubectl
 require_command helm
 require_command openssl
 
+case "$(cd "$(dirname "${MEDIA_PATH}")" && pwd)/$(basename "${MEDIA_PATH}")" in
+  /|/bin|/boot|/dev|/etc|/lib|/lib64|/proc|/root|/run|/sbin|/sys|/usr|/var)
+    echo "MEDIA_PATH points to a system directory. Choose a dedicated media directory." >&2
+    exit 1
+    ;;
+esac
+
 mkdir -p "${MEDIA_PATH}"
+if [ ! -d "${MEDIA_PATH}" ] || [ ! -r "${MEDIA_PATH}" ]; then
+  echo "MEDIA_PATH must be a readable directory: ${MEDIA_PATH}" >&2
+  exit 1
+fi
+
 KIND_CONFIG="$(mktemp)"
 trap 'rm -f "${KIND_CONFIG}"' EXIT
 
@@ -57,6 +69,7 @@ kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply
 helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}" \
   --namespace "${NAMESPACE}" \
   --set media.hostPath="${NODE_MEDIA_PATH}" \
+  --set media.mountPath="${NODE_MEDIA_PATH}" \
   --set web.port="${WEB_PORT}" \
   --set web.service.nodePort="${NODE_PORT}" \
   --set secrets.postgresPassword="${POSTGRES_PASSWORD}" \

--- a/scripts/kind-deploy.sh
+++ b/scripts/kind-deploy.sh
@@ -10,7 +10,7 @@ MEDIA_PATH="${MEDIA_PATH:-${ROOT_DIR}/media}"
 NODE_MEDIA_PATH="${KIND_NODE_MEDIA_PATH:-/media/videos}"
 WEB_PORT="${WEB_PORT:-3745}"
 NODE_PORT="${NODE_PORT:-30080}"
-POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-password}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-$(openssl rand -hex 24)}"
 SESSION_SECRET="${SESSION_SECRET:-$(openssl rand -hex 32)}"
 ENCRYPTION_KEY="${ENCRYPTION_KEY:-$(openssl rand -base64 32)}"
 
@@ -28,15 +28,26 @@ require_command helm
 require_command openssl
 require_command realpath
 
+is_system_path() {
+  local path="$1"
+  local system_dirs=(/ /bin /boot /dev /etc /lib /lib64 /proc /root /run /sbin /sys /usr /var)
+
+  for dir in "${system_dirs[@]}"; do
+    if [ "${path}" = "${dir}" ] || [[ "${path}" == "${dir}/"* ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 mkdir -p "${MEDIA_PATH}"
 MEDIA_PATH_REAL="$(realpath "${MEDIA_PATH}")"
 
-case "${MEDIA_PATH_REAL}" in
-  /|/bin|/bin/*|/boot|/boot/*|/dev|/dev/*|/etc|/etc/*|/lib|/lib/*|/lib64|/lib64/*|/proc|/proc/*|/root|/root/*|/run|/run/*|/sbin|/sbin/*|/sys|/sys/*|/usr|/usr/*|/var|/var/*)
-    echo "MEDIA_PATH points to a system directory. Choose a dedicated media directory." >&2
-    exit 1
-    ;;
-esac
+if is_system_path "${MEDIA_PATH_REAL}"; then
+  echo "MEDIA_PATH points to a system directory. Choose a dedicated media directory." >&2
+  exit 1
+fi
 
 if [ ! -d "${MEDIA_PATH_REAL}" ] || [ ! -r "${MEDIA_PATH_REAL}" ]; then
   echo "MEDIA_PATH must be a readable directory: ${MEDIA_PATH}" >&2

--- a/scripts/kind-deploy.sh
+++ b/scripts/kind-deploy.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHART_DIR="${ROOT_DIR}/charts/edit-mind"
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-edit-mind}"
+NAMESPACE="${KIND_NAMESPACE:-edit-mind}"
+RELEASE_NAME="${HELM_RELEASE_NAME:-edit-mind}"
+MEDIA_PATH="${MEDIA_PATH:-${ROOT_DIR}/media}"
+NODE_MEDIA_PATH="${KIND_NODE_MEDIA_PATH:-/media/videos}"
+WEB_PORT="${WEB_PORT:-3745}"
+NODE_PORT="${NODE_PORT:-30080}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-password}"
+SESSION_SECRET="${SESSION_SECRET:-$(openssl rand -hex 32)}"
+ENCRYPTION_KEY="${ENCRYPTION_KEY:-$(openssl rand -base64 32)}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_command docker
+require_command kind
+require_command kubectl
+require_command helm
+require_command openssl
+
+mkdir -p "${MEDIA_PATH}"
+KIND_CONFIG="$(mktemp)"
+trap 'rm -f "${KIND_CONFIG}"' EXIT
+
+cat > "${KIND_CONFIG}" <<CONFIG
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: ${NODE_PORT}
+        hostPort: ${WEB_PORT}
+        protocol: TCP
+    extraMounts:
+      - hostPath: ${MEDIA_PATH}
+        containerPath: ${NODE_MEDIA_PATH}
+CONFIG
+
+if ! kind get clusters | grep -qx "${CLUSTER_NAME}"; then
+  kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}"
+else
+  echo "Using existing Kind cluster '${CLUSTER_NAME}'."
+fi
+
+kubectl config use-context "kind-${CLUSTER_NAME}"
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}" \
+  --namespace "${NAMESPACE}" \
+  --set media.hostPath="${NODE_MEDIA_PATH}" \
+  --set web.port="${WEB_PORT}" \
+  --set web.service.nodePort="${NODE_PORT}" \
+  --set secrets.postgresPassword="${POSTGRES_PASSWORD}" \
+  --set secrets.sessionSecret="${SESSION_SECRET}" \
+  --set secrets.encryptionKey="${ENCRYPTION_KEY}" \
+  "$@"
+
+cat <<MESSAGE
+
+Edit Mind is being deployed to Kind cluster '${CLUSTER_NAME}'.
+
+Media directory: ${MEDIA_PATH}
+Namespace: ${NAMESPACE}
+Release: ${RELEASE_NAME}
+URL: http://localhost:${WEB_PORT}
+
+Check rollout status with:
+  kubectl -n ${NAMESPACE} get pods
+MESSAGE

--- a/scripts/ubuntu-setup-gpu.sh
+++ b/scripts/ubuntu-setup-gpu.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Configure an Ubuntu host so kind clusters launched by scripts/kind-deploy.sh
+# can use the local NVIDIA GPU. Idempotent — safe to re-run.
+#
+# Run with sudo:  sudo bash scripts/ubuntu-setup-gpu.sh
+set -euo pipefail
+
+if [ "${EUID}" -ne 0 ]; then
+  echo "This script must run as root. Try: sudo bash $0" >&2
+  exit 1
+fi
+
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+  echo "nvidia-smi not found. Install the NVIDIA driver first." >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker not found. Install docker first." >&2
+  exit 1
+fi
+
+if ! dpkg -s nvidia-container-toolkit >/dev/null 2>&1; then
+  echo "Installing nvidia-container-toolkit..."
+  if ! grep -rq "nvidia.github.io/libnvidia-container" /etc/apt/sources.list.d/ /etc/apt/sources.list 2>/dev/null; then
+    distribution="$(. /etc/os-release; echo "${ID}${VERSION_ID}")"
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+    curl -fsSL "https://nvidia.github.io/libnvidia-container/${distribution}/libnvidia-container.list" \
+      | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+      > /etc/apt/sources.list.d/nvidia-container-toolkit.list
+  fi
+  apt-get update
+  apt-get install -y nvidia-container-toolkit
+else
+  echo "nvidia-container-toolkit already installed."
+fi
+
+NEED_DOCKER_RESTART="false"
+
+if ! docker info 2>/dev/null | grep -q '^ Default Runtime: nvidia'; then
+  echo "Configuring docker to use the nvidia runtime by default..."
+  nvidia-ctk runtime configure --runtime=docker --set-as-default
+  NEED_DOCKER_RESTART="true"
+else
+  echo "docker default runtime is already nvidia."
+fi
+
+CONFIG_FILE="/etc/nvidia-container-runtime/config.toml"
+if [ -f "${CONFIG_FILE}" ]; then
+  CURRENT_VALUE="$(nvidia-ctk config --config-file "${CONFIG_FILE}" 2>/dev/null \
+    | awk -F'=' '/^accept-nvidia-visible-devices-as-volume-mounts/ {gsub(/[ \t]/,"",$2); print $2}')"
+  if [ "${CURRENT_VALUE}" != "true" ]; then
+    echo "Enabling accept-nvidia-visible-devices-as-volume-mounts..."
+    nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=true --in-place
+    NEED_DOCKER_RESTART="true"
+  else
+    echo "accept-nvidia-visible-devices-as-volume-mounts is already true."
+  fi
+fi
+
+if [ "${NEED_DOCKER_RESTART}" = "true" ]; then
+  echo "Restarting docker..."
+  systemctl restart docker
+fi
+
+echo
+echo "Smoke test: docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi"
+docker run --rm --gpus all nvidia/cuda:12.4.0-base-ubuntu22.04 nvidia-smi >/dev/null
+echo "GPU passthrough verified."
+
+cat <<'MESSAGE'
+
+Host is ready for GPU-enabled kind clusters.
+
+Next: recreate the kind cluster so it picks up the new docker runtime config.
+  kind delete cluster --name edit-mind
+  bash scripts/kind-deploy.sh
+MESSAGE


### PR DESCRIPTION
This pull request introduces a full-featured Helm chart for deploying the Edit Mind application and its supporting services on Kubernetes, with special support for local development using Kind. The changes add all necessary Kubernetes manifests (deployments, statefulsets, services, config, secrets, and persistent storage), a comprehensive default configuration, and updated documentation for Kubernetes-based workflows.

The most important changes are:

**Helm Chart and Kubernetes Manifests:**

* Added a new Helm chart at `charts/edit-mind` with all required templates for deploying Edit Mind and its dependencies (web, background-jobs, ML, Chroma, Redis, Postgres) as Kubernetes resources, including deployments, statefulsets, services, configmaps, secrets, and persistent volume claims. [[1]](diffhunk://#diff-4aefd18a592af9b5a71b689005d0552a4d8e05ce5942a121444913754870a6c9R1-R6) [[2]](diffhunk://#diff-40b7210e2d060edd3be9deb88d6e9227d7ad3143c66288dba557fea16009a1ccR1-R193) [[3]](diffhunk://#diff-5f49f9836f235d2feaa56015feacbc7863fa3c248bbcc4585a894f73db52f1f9R1-R97) [[4]](diffhunk://#diff-37d416453feb1aad3c2e5fb556b433ce9096b81c595a9d80893ddd1ec8fa1f9eR1-R147) [[5]](diffhunk://#diff-6c75245e86306eab184cdc2f05e105e2a31f0b2bbfdb1e4b3a7caf1379e27508R1-R35) [[6]](diffhunk://#diff-5b9bfc86a37d0efb764562d8ee19b592f19de0adbe008ed9df33c0d80ad59645R1-R17) [[7]](diffhunk://#diff-2ddc9d54065dc1da1fa39eaa28691a5baae744e67c0fdba218417c246407b955R1-R15)

**Configuration and Customization:**

* Introduced a comprehensive `values.yaml` file for the Helm chart, allowing users to configure images, ports, resource requests, GPU support, secrets, persistence, and environment variables for all components.

**Documentation Updates:**

* Updated `README.md` to document the new Kubernetes deployment workflow, including prerequisites, usage of the provided `kind-deploy.sh` script, and instructions for manual Helm installation and configuration overrides.
* Added installation notes in `charts/edit-mind/templates/NOTES.txt` to guide users on accessing the application after deploying with Helm.

These changes enable users to deploy Edit Mind on any Kubernetes cluster, with easy local development using Kind and Helm, and provide flexibility for production deployments.