### PR TITLE
feat: add opt-in TwelveLabs analyzer plugin (Pegasus + Marengo)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,13 @@ OLLAMA_PORT=""
 GEMINI_API_KEY=""
 USE_GEMINI="false"
 
-# Ports Mapping 
+# TwelveLabs Option (optional, opt-in)
+# Enables the TwelveLabs analyzer plugin: Pegasus whole-video descriptions
+# + Marengo 512-dim multimodal embeddings. Leave blank to keep things local.
+# Free API key: https://twelvelabs.io
+TWELVELABS_API_KEY=""
+
+# Ports Mapping
 CHROMA_PORT=8000 
 PORT=3745 
 BACKGROUND_JOBS_PORT=4000 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,24 @@ openssl rand -base64 32
 openssl rand -hex 32
 ```
 
+#### Optional: TwelveLabs video understanding
+
+The ML service ships an **opt-in** TwelveLabs analyzer plugin. When you set a
+`TWELVELABS_API_KEY`, every analyzed video also gets:
+
+- a rich whole-video description from **Pegasus**, which flows into the existing
+  semantic-search pipeline alongside the local BLIP captions, and
+- a 512-dim multimodal **Marengo** embedding, exposed in the plugin results for
+  vector indexing.
+
+```ini
+# Optional, opt-in. Leave blank to keep analysis fully local.
+TWELVELABS_API_KEY="your-twelvelabs-api-key"
+```
+
+Without the key the plugin is a no-op and nothing changes. Grab a free key at
+[twelvelabs.io](https://twelvelabs.io) — there's a generous free tier.
+
 
 ### 4. Start the Services
 

--- a/python/core/config.py
+++ b/python/core/config.py
@@ -20,6 +20,13 @@ class AnalysisConfig:
         'ShotTypePlugin': 1,
         "DescriptorPlugin": 1
     })
+    # Opt-in TwelveLabs plugin (Pegasus analysis + Marengo embeddings).
+    # No-op unless twelvelabs_api_key or the TWELVELABS_API_KEY env var is set.
+    twelvelabs_api_key: Optional[str] = field(
+        default_factory=lambda: os.getenv("TWELVELABS_API_KEY")
+    )
+    twelvelabs_prompt: Optional[str] = None
+    twelvelabs_embedding: bool = True
     thumbnail_dir: str = field(
         default_factory=lambda: os.getenv(
             "THUMBNAILS_PATH",

--- a/python/plugins/twelvelabs.py
+++ b/python/plugins/twelvelabs.py
@@ -1,0 +1,204 @@
+"""TwelveLabs video understanding plugin (opt-in).
+
+Uses TwelveLabs' cloud models to enrich the local-first knowledge base:
+
+* **Pegasus** generates a rich, whole-video natural-language description that
+  is attached to every sampled frame (mirroring :class:`DescriptorPlugin`),
+  so it flows straight into the existing transcription/NLP and ChromaDB
+  semantic-search pipeline.
+* **Marengo** produces a 512-dimensional multimodal video embedding, exposed
+  through :meth:`get_results` for callers that want to index videos in a
+  vector store.
+
+The plugin is fully opt-in: it only contacts the network when a
+``TWELVELABS_API_KEY`` is present in the environment (or in the analysis
+config). Without a key it loads as a no-op and changes nothing, so existing
+local-only behaviour is preserved. Failures degrade gracefully and never abort
+an analysis job.
+
+Get a free API key at https://twelvelabs.io (generous free tier).
+"""
+from typing import Dict, List, Optional, Union
+import os
+
+import numpy as np
+
+from plugins.base import AnalyzerPlugin, FrameAnalysis, PluginResult
+from core.config import AnalysisConfig
+from services.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Whole-video Pegasus prompt. Kept generic so descriptions are useful for
+# semantic search across an arbitrary personal video library.
+DEFAULT_PROMPT = (
+    "Describe this video in detail. Cover the setting, the people and objects "
+    "present, the main actions and events, and the overall mood. Write a "
+    "single dense paragraph optimised for search."
+)
+
+# Model identifiers (TwelveLabs SDK >= 1.2.8).
+PEGASUS_MODEL = "pegasus1.5"
+MARENGO_MODEL = "marengo3.0"
+
+# How long to wait for the async Marengo embedding task to finish (seconds).
+EMBED_TIMEOUT_SEC = 300
+
+
+class TwelveLabsPlugin(AnalyzerPlugin):
+    """Whole-video understanding via TwelveLabs Pegasus + Marengo.
+
+    Unlike the frame-by-frame plugins, TwelveLabs analyses the whole video in
+    the cloud. The expensive upload + analysis happens once per job in
+    :meth:`setup`; :meth:`analyze_frame` then cheaply tags each sampled frame
+    with the resulting description.
+    """
+
+    def __init__(self, config: AnalysisConfig):
+        super().__init__(config)
+        # config is passed to plugins as a dict (see PluginManager._load_plugins).
+        self.api_key: Optional[str] = self._read_api_key(config)
+        self.prompt: str = (
+            self._read_config(config, "twelvelabs_prompt", None) or DEFAULT_PROMPT
+        )
+        self.enable_embedding: bool = bool(
+            self._read_config(config, "twelvelabs_embedding", True)
+        )
+        self.client = None
+        self.description: Optional[str] = None
+        self.embedding: Optional[List[float]] = None
+
+    @staticmethod
+    def _read_config(config, key: str, default):
+        """config may be a dict (runtime) or an AnalysisConfig (tests)."""
+        if isinstance(config, dict):
+            return config.get(key, default)
+        return getattr(config, key, default)
+
+    def _read_api_key(self, config) -> Optional[str]:
+        key = self._read_config(config, "twelvelabs_api_key", None)
+        return key or os.environ.get("TWELVELABS_API_KEY")
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.api_key)
+
+    def load_models(self) -> None:
+        """Construct the API client once per process (no heavy local model)."""
+        if not self.enabled:
+            logger.info(
+                "TwelveLabsPlugin disabled: set TWELVELABS_API_KEY to enable "
+                "Pegasus analysis + Marengo embeddings."
+            )
+            return
+        try:
+            from twelvelabs import TwelveLabs
+        except ImportError:
+            logger.error(
+                "TwelveLabsPlugin enabled but the 'twelvelabs' package is not "
+                "installed. Run: pip install 'twelvelabs>=1.2.8'."
+            )
+            self.api_key = None
+            return
+        self.client = TwelveLabs(api_key=self.api_key)
+        logger.info("TwelveLabsPlugin ready (Pegasus + Marengo)")
+
+    def setup(self, video_path: str, job_id: str) -> None:
+        """Run whole-video Pegasus analysis (and Marengo embedding) once."""
+        self.description = None
+        self.embedding = None
+        if not self.enabled or self.client is None:
+            return
+
+        self.description = self._analyze(video_path)
+        if self.enable_embedding:
+            self.embedding = self._embed(video_path)
+
+    def _analyze(self, video_path: str) -> Optional[str]:
+        """Pegasus whole-video description.
+
+        Pegasus reads from a server-side asset, so the local file is uploaded
+        once as a TwelveLabs asset and referenced by id.
+        """
+        try:
+            from twelvelabs.types.video_context import VideoContext_AssetId
+
+            with open(video_path, "rb") as f:
+                asset = self.client.assets.create(method="direct", file=f)
+
+            resp = self.client.analyze(
+                model_name=PEGASUS_MODEL,
+                video=VideoContext_AssetId(asset_id=asset.id),
+                prompt=self.prompt,
+                max_tokens=2048,
+            )
+            text = (resp.data or "").strip().lower()
+            logger.info("TwelveLabs Pegasus described video (%d chars)", len(text))
+            return text or None
+        except Exception as e:  # noqa: BLE001 - degrade gracefully, never fail a job
+            logger.error("TwelveLabs Pegasus analysis failed: %s", e)
+            return None
+
+    def _embed(self, video_path: str) -> Optional[List[float]]:
+        """Marengo 512-dim multimodal video embedding (async task)."""
+        try:
+            with open(video_path, "rb") as f:
+                task = self.client.embed.tasks.create(
+                    model_name=MARENGO_MODEL,
+                    video_file=f,
+                    video_embedding_scope=["video"],
+                )
+            self.client.embed.tasks.wait_for_done(
+                task_id=task.id,
+                request_options={"timeout_in_seconds": EMBED_TIMEOUT_SEC},
+            )
+            result = self.client.embed.tasks.retrieve(task_id=task.id)
+            segments = (
+                result.video_embedding.segments if result.video_embedding else []
+            ) or []
+            if not segments:
+                return None
+            vector = list(segments[0].float_)
+            logger.info("TwelveLabs Marengo embedded video (%d dims)", len(vector))
+            return vector
+        except Exception as e:  # noqa: BLE001 - degrade gracefully
+            logger.error("TwelveLabs Marengo embedding failed: %s", e)
+            return None
+
+    def analyze_frame(
+        self,
+        frame: np.ndarray,
+        frame_analysis: FrameAnalysis,
+        video_path: str,
+    ) -> FrameAnalysis:
+        """Attach the whole-video description to each sampled frame.
+
+        Pegasus describes the video as a whole, so every frame carries the same
+        description. We only set it when no other plugin (e.g. BLIP) has
+        already produced a per-frame caption, keeping the integration additive.
+        """
+        if self.description and not frame_analysis.get("description"):
+            frame_analysis["description"] = self.description
+        return frame_analysis
+
+    def get_results(self) -> PluginResult:
+        if not self.description and not self.embedding:
+            return None
+        result: Dict[str, Union[str, List[float], int]] = {}
+        if self.description:
+            result["description"] = self.description
+        if self.embedding:
+            result["embedding"] = self.embedding
+            result["embedding_model"] = MARENGO_MODEL
+            result["embedding_dim"] = len(self.embedding)
+        return result
+
+    def get_summary(self) -> PluginResult:
+        return {"description": self.description} if self.description else None
+
+    def cleanup(self) -> None:
+        self.description = None
+        self.embedding = None
+
+    def cleanup_models(self) -> None:
+        self.client = None

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -39,3 +39,7 @@ tf-keras
 ultralytics>=8.0.0
 transformers>=4.35.0
 --index-url https://pypi.org/simple
+
+# TwelveLabs (optional, opt-in cloud video understanding plugin)
+# Only imported when TWELVELABS_API_KEY is set; safe to remove if unused.
+twelvelabs>=1.2.8

--- a/python/services/analysis/plugins.py
+++ b/python/services/analysis/plugins.py
@@ -52,6 +52,8 @@ class PluginManager:
             ("DominantColorPlugin", "dominant_color"),
             ("DescriptorPlugin", "descriptor"),
             ("TextDetectionPlugin", "text_detection"),
+            # Opt-in: only does anything when TWELVELABS_API_KEY is set.
+            ("TwelveLabsPlugin", "twelvelabs"),
         ]
 
         for plugin_name, module_stem in plugin_definitions:

--- a/python/tests/test_twelvelabs_plugin.py
+++ b/python/tests/test_twelvelabs_plugin.py
@@ -1,0 +1,92 @@
+"""Tests for the opt-in TwelveLabs plugin.
+
+The network test is skipped unless TWELVELABS_API_KEY is set, so the suite
+stays green in CI/local-only environments. The unit tests need no network.
+
+Run from the ``python/`` directory:  pytest tests/test_twelvelabs_plugin.py
+"""
+import os
+
+import numpy as np
+import pytest
+
+from plugins.twelvelabs import TwelveLabsPlugin, MARENGO_MODEL, DEFAULT_PROMPT
+
+
+def test_disabled_without_api_key(monkeypatch):
+    """No key -> plugin is a pure no-op and never touches the network."""
+    monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+    plugin = TwelveLabsPlugin({})
+
+    assert plugin.enabled is False
+
+    plugin.load_models()  # must not construct a client or raise
+    assert plugin.client is None
+
+    plugin.setup("does-not-exist.mp4", job_id="job1")  # must not hit the API
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    out = plugin.analyze_frame(frame, {}, "does-not-exist.mp4")
+
+    assert "description" not in out
+    assert plugin.get_results() is None
+    assert plugin.get_summary() is None
+
+
+def test_enabled_with_api_key_in_config():
+    """Key supplied via config (not env) flips the plugin on."""
+    plugin = TwelveLabsPlugin({"twelvelabs_api_key": "test-key"})
+    assert plugin.enabled is True
+    assert plugin.prompt == DEFAULT_PROMPT
+
+
+def test_config_overrides():
+    plugin = TwelveLabsPlugin(
+        {
+            "twelvelabs_api_key": "k",
+            "twelvelabs_prompt": "custom prompt",
+            "twelvelabs_embedding": False,
+        }
+    )
+    assert plugin.prompt == "custom prompt"
+    assert plugin.enable_embedding is False
+
+
+def test_analyze_frame_tags_description_additively():
+    """Pegasus description fills in only when no other plugin captioned."""
+    plugin = TwelveLabsPlugin({"twelvelabs_api_key": "k"})
+    plugin.description = "a dog runs on a beach"
+
+    blank = plugin.analyze_frame(np.zeros((2, 2, 3), np.uint8), {}, "v.mp4")
+    assert blank["description"] == "a dog runs on a beach"
+
+    # Existing caption from another plugin is preserved.
+    existing = plugin.analyze_frame(
+        np.zeros((2, 2, 3), np.uint8), {"description": "blip caption"}, "v.mp4"
+    )
+    assert existing["description"] == "blip caption"
+
+
+def test_get_results_shape():
+    plugin = TwelveLabsPlugin({"twelvelabs_api_key": "k"})
+    plugin.description = "desc"
+    plugin.embedding = [0.0] * 512
+    result = plugin.get_results()
+    assert result["description"] == "desc"
+    assert result["embedding_dim"] == 512
+    assert result["embedding_model"] == MARENGO_MODEL
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TWELVELABS_API_KEY"),
+    reason="requires TWELVELABS_API_KEY (network)",
+)
+def test_marengo_text_embedding_is_512d():
+    """Live check: Marengo returns a 512-dim multimodal embedding."""
+    from twelvelabs import TwelveLabs
+
+    client = TwelveLabs(api_key=os.environ["TWELVELABS_API_KEY"])
+    resp = client.embed.create(
+        model_name=MARENGO_MODEL, text="a person riding a bicycle in a park"
+    )
+    vector = resp.text_embedding.segments[0].float_
+    assert len(vector) == 512


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This adds an **opt-in** TwelveLabs analyzer plugin to the Python ML service, extending the local-first knowledge base with cloud video understanding when (and only when) a key is present.

### What it adds
- `python/plugins/twelvelabs.py` — a new `TwelveLabsPlugin` (subclass of `AnalyzerPlugin`) that, per analyzed video:
  - runs **Pegasus** for a rich whole-video description, attached to sampled frames the same way `DescriptorPlugin` (BLIP) does, so it flows straight into the existing transcription/NLP + ChromaDB semantic-search pipeline. It only fills `description` when no other plugin already captioned the frame, so it's purely additive.
  - produces a 512-dim **Marengo** multimodal video embedding, exposed via `get_results()` for vector indexing.
- Wired into `PluginManager` (`services/analysis/plugins.py`) the same way the other plugins are registered.
- Config knobs on `AnalysisConfig` (`twelvelabs_api_key`, `twelvelabs_prompt`, `twelvelabs_embedding`) that default to the `TWELVELABS_API_KEY` env var.

### Why it helps
Pegasus descriptions meaningfully improve semantic search recall over frame-level BLIP captions (whole-scene context, actions, mood), and Marengo gives a single 512-dim vector per video for fast similarity. Both are optional enrichments on top of the existing local pipeline.

### Opt-in / non-breaking
Without `TWELVELABS_API_KEY` the plugin loads as a **no-op** — no network, no behavior change, existing local-only flow is untouched. The `twelvelabs` SDK is a soft dependency (lazy-imported only when enabled). Failures degrade gracefully and never abort a job.

### How it was tested
- `python/tests/test_twelvelabs_plugin.py`: 5 no-network unit tests (disabled-without-key no-op, config plumbing, additive frame tagging, result shape) + 1 live test gated on `TWELVELABS_API_KEY` (skipped in CI without it).
- All 6 pass locally; the live test confirms Marengo returns a **512-dim** vector. SDK call contracts (`assets.create` → `analyze(video=VideoContext_AssetId)`, `embed.tasks.create`/`wait_for_done`/`retrieve`) verified against `twelvelabs==1.2.8`.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional TwelveLabs video understanding support for users who provide an API key.
  * Videos can now receive richer whole-video descriptions and optional embedding metadata for downstream search and indexing.
  * Updated setup docs and sample environment settings to show how to enable the feature.

* **Bug Fixes**
  * The new feature stays inactive when not configured, avoiding impact for existing setups.
  * Processing failures now fall back gracefully without interrupting analysis jobs.

* **Tests**
  * Added coverage for enabled/disabled behavior, configuration overrides, and embedding output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->